### PR TITLE
Fix Serialization/Deserialization of SurrogatePairs

### DIFF
--- a/SpanJson.Benchmarks/Program.cs
+++ b/SpanJson.Benchmarks/Program.cs
@@ -8,18 +8,7 @@ namespace SpanJson.Benchmarks
     {
         private static void Main(string[] args)
         {
-
-            var input = new Input {Text = "Hello World"};
-
-            var serialized = JsonSerializer.Generic.Utf16.Serialize(input);
-
-            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<Input>(serialized);
             BenchmarkRunner.Run<SelectedBenchmarks>();
         }
-    }
-
-    public class Input
-    {
-        public string Text { get; set; }
     }
 }

--- a/SpanJson.Benchmarks/SelectedBenchmarks.cs
+++ b/SpanJson.Benchmarks/SelectedBenchmarks.cs
@@ -43,34 +43,34 @@ namespace SpanJson.Benchmarks
 
         //private static readonly Utf8JsonSerializer Utf8JsonSerializer = new Utf8JsonSerializer();
 
-        //private static readonly MobileBadgeAward MobileBadgeAwardInput = ExpressionTreeFixture.Create<MobileBadgeAward>();
+        private static readonly MobileBadgeAward MobileBadgeAwardInput = ExpressionTreeFixture.Create<MobileBadgeAward>();
 
-        //private static readonly string MobileBadgeAwardSerializedString = JsonSerializer.Generic.Utf16.Serialize(MobileBadgeAwardInput);
-        //private static readonly byte[] MobileBadgeAwardSerializedByteArray = JsonSerializer.Generic.Utf8.Serialize(MobileBadgeAwardInput);
+        private static readonly string MobileBadgeAwardSerializedString = JsonSerializer.Generic.Utf16.Serialize(MobileBadgeAwardInput);
+        private static readonly byte[] MobileBadgeAwardSerializedByteArray = JsonSerializer.Generic.Utf8.Serialize(MobileBadgeAwardInput);
 
-        //[Benchmark]
-        //public string SerializeMobileBadgeAwardWithSpanJsonSerializer()
-        //{
-        //    return SpanJsonSerializer.Serialize(MobileBadgeAwardInput);
-        //}
+        [Benchmark]
+        public string SerializeMobileBadgeAwardWithSpanJsonSerializer()
+        {
+            return SpanJsonSerializer.Serialize(MobileBadgeAwardInput);
+        }
 
-        //[Benchmark]
-        //public byte[] SerializeMobileBadgeAwardWithSpanJsonSerializerUtf8()
-        //{
-        //    return JsonSerializer.Generic.Utf8.Serialize(MobileBadgeAwardInput);
-        //}
+        [Benchmark]
+        public byte[] SerializeMobileBadgeAwardWithSpanJsonSerializerUtf8()
+        {
+            return JsonSerializer.Generic.Utf8.Serialize(MobileBadgeAwardInput);
+        }
 
-        //[Benchmark]
-        //public MobileBadgeAward DeserializeMobileBadgeAwardWithSpanJsonSerializer()
-        //{
-        //    return SpanJsonSerializer.Deserialize<MobileBadgeAward>(MobileBadgeAwardSerializedString);
-        //}
+        [Benchmark]
+        public MobileBadgeAward DeserializeMobileBadgeAwardWithSpanJsonSerializer()
+        {
+            return SpanJsonSerializer.Deserialize<MobileBadgeAward>(MobileBadgeAwardSerializedString);
+        }
 
-        //[Benchmark]
-        //public MobileBadgeAward DeserializeMobileBadgeAwardWithSpanJsonSerializerUtf8()
-        //{
-        //    return JsonSerializer.Generic.Utf8.Deserialize<MobileBadgeAward>(MobileBadgeAwardSerializedByteArray);
-        //}
+        [Benchmark]
+        public MobileBadgeAward DeserializeMobileBadgeAwardWithSpanJsonSerializerUtf8()
+        {
+            return JsonSerializer.Generic.Utf8.Deserialize<MobileBadgeAward>(MobileBadgeAwardSerializedByteArray);
+        }
 
         //[Benchmark]
         //public string SerializeAnswerWithSpanJsonSerializer()
@@ -404,63 +404,63 @@ namespace SpanJson.Benchmarks
         //    return SpanJsonUtf8Serializer.Serialize(SingleInput);
         //}
 
-        private static readonly System.DateTime DateTimeInput = ExpressionTreeFixture.Create<System.DateTime>();
+        //private static readonly System.DateTime DateTimeInput = ExpressionTreeFixture.Create<System.DateTime>();
 
-        private static readonly System.DateTimeOffset DateTimeOffsetInput = ExpressionTreeFixture.Create<System.DateTimeOffset>();
+        //private static readonly System.DateTimeOffset DateTimeOffsetInput = ExpressionTreeFixture.Create<System.DateTimeOffset>();
 
-        [Benchmark]
-        public System.String SerializeDateTimeWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Serialize(DateTimeInput);
-        }
-
-
-        [Benchmark]
-        public System.Byte[] SerializeDateTimeWithSpanJsonUtf8Serializer()
-        {
-            return SpanJsonUtf8Serializer.Serialize(DateTimeInput);
-        }
-
-        [Benchmark]
-        public System.String SerializeDateTimeOffsetWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Serialize(DateTimeOffsetInput);
-        }
+        //[Benchmark]
+        //public System.String SerializeDateTimeWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Serialize(DateTimeInput);
+        //}
 
 
-        [Benchmark]
-        public System.Byte[] SerializeDateTimeOffsetWithSpanJsonUtf8Serializer()
-        {
-            return SpanJsonUtf8Serializer.Serialize(DateTimeOffsetInput);
-        }
+        //[Benchmark]
+        //public System.Byte[] SerializeDateTimeWithSpanJsonUtf8Serializer()
+        //{
+        //    return SpanJsonUtf8Serializer.Serialize(DateTimeInput);
+        //}
 
-        private static readonly Byte[] DateTimeOffsetOutputOfSpanJsonUtf8Serializer = SpanJsonUtf8Serializer.Serialize(DateTimeOffsetInput);
-        [Benchmark]
-        public System.DateTimeOffset DeserializeDateTimeOffsetWithSpanJsonUtf8Serializer()
-        {
-            return SpanJsonUtf8Serializer.Deserialize<System.DateTimeOffset>(DateTimeOffsetOutputOfSpanJsonUtf8Serializer);
-        }
+        //[Benchmark]
+        //public System.String SerializeDateTimeOffsetWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Serialize(DateTimeOffsetInput);
+        //}
 
-        private static readonly string DateTimeOffsetOutputOfSpanJsonSerializer = SpanJsonSerializer.Serialize(DateTimeOffsetInput);
-        [Benchmark]
-        public System.DateTimeOffset DeserializeDateTimeOffsetWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Deserialize<System.DateTimeOffset>(DateTimeOffsetOutputOfSpanJsonSerializer);
-        }
 
-        private static readonly byte[] DateTimeOutputOfSpanJsonUtf8Serializer = SpanJsonUtf8Serializer.Serialize(DateTimeInput);
-        [Benchmark]
-        public System.DateTimeOffset DeserializeDateTimetWithSpanUtf8JsonSerializer()
-        {
-            return SpanJsonUtf8Serializer.Deserialize<System.DateTime>(DateTimeOutputOfSpanJsonUtf8Serializer);
-        }
+        //[Benchmark]
+        //public System.Byte[] SerializeDateTimeOffsetWithSpanJsonUtf8Serializer()
+        //{
+        //    return SpanJsonUtf8Serializer.Serialize(DateTimeOffsetInput);
+        //}
 
-        private static readonly string DateTimeOutputOfSpanJsonSerializer = SpanJsonSerializer.Serialize(DateTimeInput);
-        [Benchmark]
-        public System.DateTime DeserializeDateTimeWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Deserialize<System.DateTime>(DateTimeOutputOfSpanJsonSerializer);
-        }
+        //private static readonly Byte[] DateTimeOffsetOutputOfSpanJsonUtf8Serializer = SpanJsonUtf8Serializer.Serialize(DateTimeOffsetInput);
+        //[Benchmark]
+        //public System.DateTimeOffset DeserializeDateTimeOffsetWithSpanJsonUtf8Serializer()
+        //{
+        //    return SpanJsonUtf8Serializer.Deserialize<System.DateTimeOffset>(DateTimeOffsetOutputOfSpanJsonUtf8Serializer);
+        //}
+
+        //private static readonly string DateTimeOffsetOutputOfSpanJsonSerializer = SpanJsonSerializer.Serialize(DateTimeOffsetInput);
+        //[Benchmark]
+        //public System.DateTimeOffset DeserializeDateTimeOffsetWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Deserialize<System.DateTimeOffset>(DateTimeOffsetOutputOfSpanJsonSerializer);
+        //}
+
+        //private static readonly byte[] DateTimeOutputOfSpanJsonUtf8Serializer = SpanJsonUtf8Serializer.Serialize(DateTimeInput);
+        //[Benchmark]
+        //public System.DateTimeOffset DeserializeDateTimetWithSpanUtf8JsonSerializer()
+        //{
+        //    return SpanJsonUtf8Serializer.Deserialize<System.DateTime>(DateTimeOutputOfSpanJsonUtf8Serializer);
+        //}
+
+        //private static readonly string DateTimeOutputOfSpanJsonSerializer = SpanJsonSerializer.Serialize(DateTimeInput);
+        //[Benchmark]
+        //public System.DateTime DeserializeDateTimeWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Deserialize<System.DateTime>(DateTimeOutputOfSpanJsonSerializer);
+        //}
 
         //private static readonly string Int64Value = ExpressionTreeFixture.Create<long>().ToString();
         //private static readonly byte[] Int64ValueBytes = Encoding.UTF8.GetBytes(Int64Value);

--- a/SpanJson.Tests/SerializationTests.cs
+++ b/SpanJson.Tests/SerializationTests.cs
@@ -173,5 +173,33 @@ namespace SpanJson.Tests
             Assert.Contains("\"SonSpecific\":true", serialized);
             Assert.Contains("\"DaughterSpecific\":true", serialized);
         }
+
+        [Theory]
+        [InlineData("칱칳칶칹칼캠츧")]
+        [InlineData("칱칳칶칹칼캠츧\t칱칳칶칹칼캠츧")]
+        [InlineData("\t칱칳칶칹칼캠츧\t칱칳칶칹칼캠츧\n")]
+        [InlineData("😷Hello\t칱칳칶칹칼캠츧\t칱칳칶칹칼캠츧\nWorld😷")]
+        [InlineData("칱칳칶칹칼캠츧😁칱칳칶칹칼캠츧")]
+        [InlineData("Hello 😁 World")]
+        [InlineData("😷Hello 😁 World😷")]
+        public void SerializeDeserializeMultiCharStringUtf8(string input)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(input);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<string>(serialized);
+            Assert.Equal(input, deserialized);
+        }
+
+        [Theory]
+        [InlineData("칱칳칶칹칼캠츧")]
+        [InlineData("칱칳칶칹칼캠츧\t칱칳칶칹칼캠츧")]
+        [InlineData("칱칳칶칹칼캠츧😁칱칳칶칹칼캠츧")]
+        [InlineData("Hello 😁 World")]
+        [InlineData("😷Hello 😁 World😷")]
+        public void SerializeDeserializeMultiCharStringUtf16(string input)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(input);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<string>(serialized);
+            Assert.Equal(input, deserialized);
+        }
     }
 }

--- a/SpanJson.Tests/SurrogateTests.cs
+++ b/SpanJson.Tests/SurrogateTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace SpanJson.Tests
+{
+    public class SurrogateTests
+    {
+        [Theory]
+        [InlineData(0x1F4A9)]
+        [InlineData(0x1F3BC)]
+        public void SurrogatePairsUtf8FromInt(int input)
+        {
+            string surrogate = Char.ConvertFromUtf32(input);
+            var utf8Bytes = Encoding.UTF8.GetBytes(surrogate);
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(surrogate);
+            Assert.True(serialized.AsSpan().Slice(1, utf8Bytes.Length).SequenceEqual(utf8Bytes));
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<string>(serialized);
+            var utf32 = Char.ConvertToUtf32(deserialized, 0);
+            Assert.Equal(input, utf32);
+        }
+
+        [Theory]
+        [InlineData("💩")]
+        [InlineData("🎼")]
+        public void SurrogatePairsUtf8FromString(string input)
+        {
+            var utf8Bytes = Encoding.UTF8.GetBytes(input);
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(input);
+            Assert.True(serialized.AsSpan().Slice(1, utf8Bytes.Length).SequenceEqual(utf8Bytes));
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<string>(serialized);
+            Assert.Equal(input, deserialized);
+        }
+
+        [Theory]
+        [InlineData("💩")]
+        [InlineData("🎼")]
+        public void SurrogatePairsUtf8CrossSerialize(string input)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(input);
+            var utf8JsonSerialized = Utf8Json.JsonSerializer.Serialize(input);
+            var utf8JsonDeserialized = Utf8Json.JsonSerializer.Deserialize<string>(serialized);
+            Assert.Equal(input, utf8JsonDeserialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<string>(utf8JsonSerialized);
+            Assert.Equal(input, deserialized);
+        }
+
+        [Theory]
+        [InlineData(0x1F4A9)]
+        [InlineData(0x1F3BC)]
+        public void SurrogatePairsUtf16(int input)
+        {
+            string surrogate = Char.ConvertFromUtf32(input);
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(surrogate);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<string>(serialized);
+            var utf32 = Char.ConvertToUtf32(deserialized, 0);
+            Assert.Equal(input, utf32);
+        }
+
+        [Theory]
+        [InlineData("💩")]
+        [InlineData("🎼")]
+        public void SurrogatePairsUtf16FromString(string input)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(input);
+            Assert.Equal($"\"{input}\"", serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<string>(serialized);
+            Assert.Equal(input, deserialized);
+        }
+    }
+}

--- a/SpanJson/SpanJson.csproj
+++ b/SpanJson/SpanJson.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>0.1.0.0-rc1-4</Version>
+    <Version>0.1.0.0-rc1-5</Version>
     <Authors>SpanJson Contributors</Authors>
     <Company />
     <Description>SpanJson is a JSON serializer for .NET Core 2.1+</Description>


### PR DESCRIPTION
Fix Serialization/Deserialization of SurrogatePairs #7 

Additionally fixed the unescaping of mixed non-ascii and json escaped chars, the previous routine did not handle that properly.
Need to run benchmarks again to see the performance impact.
