### PR TITLE
Replace string switch enum deserialization with complexformatter comparison

### DIFF
--- a/SpanJson.Benchmarks/SelectedBenchmarks.cs
+++ b/SpanJson.Benchmarks/SelectedBenchmarks.cs
@@ -69,29 +69,29 @@ namespace SpanJson.Benchmarks
         //    return JsonSerializer.Generic.Utf8.Deserialize<MobileBadgeAward>(MobileBadgeAwardSerializedByteArray);
         //}
 
-        [Benchmark]
-        public string SerializeAnswerWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Serialize(Answer);
-        }
+        //[Benchmark]
+        //public string SerializeAnswerWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Serialize(Answer);
+        //}
 
-        [Benchmark]
-        public byte[] SerializeAnswerWithSpanJsonSerializerUtf8()
-        {
-            return JsonSerializer.Generic.Utf8.Serialize(Answer);
-        }
+        //[Benchmark]
+        //public byte[] SerializeAnswerWithSpanJsonSerializerUtf8()
+        //{
+        //    return JsonSerializer.Generic.Utf8.Serialize(Answer);
+        //}
 
-        [Benchmark]
-        public Answer DeserializeAnswerWithSpanJsonSerializer()
-        {
-            return SpanJsonSerializer.Deserialize<Answer>(AnswerSerializedString);
-        }
+        //[Benchmark]
+        //public Answer DeserializeAnswerWithSpanJsonSerializer()
+        //{
+        //    return SpanJsonSerializer.Deserialize<Answer>(AnswerSerializedString);
+        //}
 
-        [Benchmark]
-        public Answer DeserializeAnswerWithSpanJsonSerializerUtf8()
-        {
-            return JsonSerializer.Generic.Utf8.Deserialize<Answer>(AnswerSerializedByteArray);
-        }
+        //[Benchmark]
+        //public Answer DeserializeAnswerWithSpanJsonSerializerUtf8()
+        //{
+        //    return JsonSerializer.Generic.Utf8.Deserialize<Answer>(AnswerSerializedByteArray);
+        //}
 
 
         //[Benchmark]
@@ -108,24 +108,24 @@ namespace SpanJson.Benchmarks
         //    return SpanJsonUtf8Serializer.Deserialize<BadgeRank>(bronze);
         //}
 
-        [Benchmark]
-        public async ValueTask<Answer> DeserializeAnswerWithSpanJsonSerializerAsyncUtf8()
-        {
-            using (var ms = new MemoryStream(AnswerSerializedByteArray, 0, AnswerSerializedByteArray.Length, false, false))
-            {
-                return await JsonSerializer.Generic.Utf8.DeserializeAsync<Answer>(ms);
-            }
-        }
+        //[Benchmark]
+        //public async ValueTask<Answer> DeserializeAnswerWithSpanJsonSerializerAsyncUtf8()
+        //{
+        //    using (var ms = new MemoryStream(AnswerSerializedByteArray, 0, AnswerSerializedByteArray.Length, false, false))
+        //    {
+        //        return await JsonSerializer.Generic.Utf8.DeserializeAsync<Answer>(ms);
+        //    }
+        //}
 
-        [Benchmark]
-        public async ValueTask<byte[]> SerializeAnswerWithSpanJsonSerializerAsyncUtf8()
-        {
-            using (var ms = new MemoryStream())
-            {
-                await JsonSerializer.Generic.Utf8.SerializeAsync(Answer, ms);
-                return ms.ToArray();
-            }
-        }
+        //[Benchmark]
+        //public async ValueTask<byte[]> SerializeAnswerWithSpanJsonSerializerAsyncUtf8()
+        //{
+        //    using (var ms = new MemoryStream())
+        //    {
+        //        await JsonSerializer.Generic.Utf8.SerializeAsync(Answer, ms);
+        //        return ms.ToArray();
+        //    }
+        //}
 
         //[Benchmark]
         //public async ValueTask<Answer> DeserializeAnswerWithJilSerializerAsync()
@@ -148,27 +148,27 @@ namespace SpanJson.Benchmarks
         //    return StringBuilder.ToString();
         //}
 
-        [Benchmark]
-        public async ValueTask<Answer> DeserializeAnswerWithSpanJsonSerializerAsync()
-        {
-            using (var tr = new StringReader(AnswerSerializedString))
-            {
-                return await JsonSerializer.Generic.Utf16.DeserializeAsync<Answer>(tr);
-            }
-        }
+        //[Benchmark]
+        //public async ValueTask<Answer> DeserializeAnswerWithSpanJsonSerializerAsync()
+        //{
+        //    using (var tr = new StringReader(AnswerSerializedString))
+        //    {
+        //        return await JsonSerializer.Generic.Utf16.DeserializeAsync<Answer>(tr);
+        //    }
+        //}
 
 
-        [Benchmark]
-        public async ValueTask<string> SerializeAnswerWithSpanJsonSerializerAsync()
-        {
-            StringBuilder.Clear();
-            using (var tw = new StringWriter(StringBuilder))
-            {
-                await JsonSerializer.Generic.Utf16.SerializeAsync(Answer, tw);
+        //[Benchmark]
+        //public async ValueTask<string> SerializeAnswerWithSpanJsonSerializerAsync()
+        //{
+        //    StringBuilder.Clear();
+        //    using (var tw = new StringWriter(StringBuilder))
+        //    {
+        //        await JsonSerializer.Generic.Utf16.SerializeAsync(Answer, tw);
 
-            }
-            return StringBuilder.ToString();
-        }
+        //    }
+        //    return StringBuilder.ToString();
+        //}
 
 
         //[Benchmark]
@@ -534,5 +534,20 @@ namespace SpanJson.Benchmarks
         //    var reader = new JsonReader<char>("true");
         //    return reader.ReadUtf16Boolean();
         //}
+
+        private static readonly string BadgeRankString = JsonSerializer.Generic.Utf16.Serialize(BadgeRank.bronze);
+        private static readonly byte[] BadgeRankBytes = Encoding.UTF8.GetBytes(BadgeRankString);
+
+        [Benchmark]
+        public BadgeRank DeserializeBadgeRankUtf16()
+        {
+            return SpanJsonSerializer.Deserialize<BadgeRank>(BadgeRankString);
+        }
+
+        [Benchmark]
+        public BadgeRank DeserializeBadgeRankUtf8()
+        {
+            return SpanJsonUtf8Serializer.Deserialize<BadgeRank>(BadgeRankBytes);
+        }
     }
 }

--- a/SpanJson.Tests/EnumTests.cs
+++ b/SpanJson.Tests/EnumTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using System.Text;
 using SpanJson.Resolvers;
@@ -51,15 +52,30 @@ namespace SpanJson.Tests
             Assert.Equal(value, deserialized);
         }
 
+        [Theory]
+        [InlineData(TestEnum.Hello)]
+        [InlineData(TestEnum.World)]
+        [InlineData(TestEnum.Universe)]
+        [InlineData(TestEnum.Renamed)]
+        public void SerializeDeserializeUtf16(TestEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<TestEnum>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
         public class TestDO
         {
             public TestEnum? Value { get; set; }
+
+            public int? AnotherValue { get; set; }
         }
 
         [Fact]
         public void SerializeDeserializeNullableEnumUtf16()
         {
-            var test = new TestDO {Value = null};
+            var test = new TestDO {Value = null, AnotherValue = 1};
             var serialized = JsonSerializer.Generic.Utf16.Serialize<TestDO, IncludeNullsOriginalCaseResolver<char>>(test);
             Assert.Contains("null", serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<TestDO, IncludeNullsOriginalCaseResolver<char>>(serialized);
@@ -70,12 +86,26 @@ namespace SpanJson.Tests
         [Fact]
         public void SerializeDeserializeNullableEnumUtf8()
         {
-            var test = new TestDO { Value = null };
+            var test = new TestDO { Value = null, AnotherValue = 1 };
             var serialized = JsonSerializer.Generic.Utf8.Serialize<TestDO, IncludeNullsOriginalCaseResolver<byte>>(test);
             Assert.Contains("null", Encoding.UTF8.GetString(serialized));
             var deserialized = JsonSerializer.Generic.Utf8.Deserialize<TestDO, IncludeNullsOriginalCaseResolver<byte>>(serialized);
             Assert.NotNull(deserialized);
             Assert.Null(deserialized.Value);
+        }
+
+        [Fact]
+        public void DeserializeUnknownEnumUtf8()
+        {
+            var serialized = Encoding.UTF8.GetBytes("{\"Value\":\"Unused\",\"AnotherValue\":1}");
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Generic.Utf8.Deserialize<TestDO>(serialized));
+        }
+
+        [Fact]
+        public void DeserializeUnknownEnumUtf16()
+        {
+            var serialized = "{\"Value\":\"Unused\",\"AnotherValue\":1}";
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Generic.Utf16.Deserialize<TestDO>(serialized));
         }
     }
 }

--- a/SpanJson/Formatters/BaseFormatter.cs
+++ b/SpanJson/Formatters/BaseFormatter.cs
@@ -62,22 +62,5 @@ namespace SpanJson.Formatters
                 RuntimeFormatter<TSymbol, TResolver>.Default.Serialize(ref writer, value, nextNestingLimit);
             }
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static int GetSymbolSize<TSymbol>() where TSymbol : struct
-        {
-
-            if (typeof(TSymbol) == typeof(char))
-            {
-                return sizeof(char);
-            }
-
-            if (typeof(TSymbol) == typeof(byte))
-            {
-                return sizeof(byte);
-            }
-
-            throw new NotSupportedException();
-        }
     }
 }

--- a/SpanJson/Helpers/MemberComparisonBuilder.cs
+++ b/SpanJson/Helpers/MemberComparisonBuilder.cs
@@ -36,6 +36,10 @@ namespace SpanJson.Helpers
         /// This is a very fast way to match the correct namespan for e.g assigning members
         /// as it's only a comparison of length (this excludes most of the values) and
         /// comparing the individual integer length parts of the name against constants
+        /// This improves the performance in deserialization specifically for UTF8 as byte arrays
+        /// are handled differently than strings for comparisons in expression trees
+        /// The speed for both is practically the same with this method
+        /// It also simplifies the code if the member name is actually multibyte utf8 (e.g. chinese)
         /// </summary>
         public static Expression Build<TSymbol>(List<JsonMemberInfo> memberInfos, int index, ParameterExpression lengthParameter,
             ParameterExpression nameSpanExpression, LabelTarget endOfBlockLabel,
@@ -168,7 +172,7 @@ namespace SpanJson.Helpers
         {
             if (typeof(TSymbol) == typeof(char))
             {
-                return CalculateKeyUtf16(memberName, index); // for calculating the key the index is actually only half as much due to two byte chars
+                return CalculateKeyUtf16(memberName, index);
             }
 
             if (typeof(TSymbol) == typeof(byte))
@@ -204,7 +208,6 @@ namespace SpanJson.Helpers
 
             return (0, typeof(uint), 0);
         }
-
 
         private static (ulong Key, Type intType, int offset) CalculateKeyUtf16(string memberName, int index)
         {

--- a/SpanJson/Helpers/MemberComparisonBuilder.cs
+++ b/SpanJson/Helpers/MemberComparisonBuilder.cs
@@ -26,7 +26,17 @@ namespace SpanJson.Helpers
 
             throw new NotSupportedException();
         }
-
+        /// <summary>
+        /// This method builds a chain of if statements  of the following logic:
+        /// if(length == x AND ReadInteger(span) == y AND ...) then assign value
+        /// the ReadInteger comparisons are basically constant values of the encoded value
+        /// UTF8 -> 8 chars -> 8 bytes
+        /// UTF16 -> 4 chars -> 8 bytes
+        /// etc.
+        /// This is a very fast way to match the correct namespan for e.g assigning members
+        /// as it's only a comparison of length (this excludes most of the values) and
+        /// comparing the individual integer length parts of the name against constants
+        /// </summary>
         public static Expression Build<TSymbol>(List<JsonMemberInfo> memberInfos, int index, ParameterExpression lengthParameter,
             ParameterExpression nameSpanExpression, LabelTarget endOfBlockLabel,
             Func<JsonMemberInfo, Expression> matchExpressionFunctor) where TSymbol : struct

--- a/SpanJson/Helpers/SpanHelper.cs
+++ b/SpanJson/Helpers/SpanHelper.cs
@@ -31,18 +31,5 @@ namespace SpanJson.Helpers
         {
             return Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), offset));
         }
-
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StringEquals(in ReadOnlySpan<char> span, string comparison)
-        {
-            return span.SequenceEqual(comparison);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool ByteEquals(in ReadOnlySpan<byte> span, byte[] comparison)
-        {
-            return span.SequenceEqual(comparison);
-        }
     }
 }


### PR DESCRIPTION
This improves the enum deserialization speed by ~10-15%.

Before:
```ini
                    Method |     Mean |     Error |    StdDev | Allocated |
-------------------------- |---------:|----------:|----------:|----------:|
 DeserializeBadgeRankUtf16 | 60.11 ns | 0.4242 ns | 0.3968 ns |       0 B |
  DeserializeBadgeRankUtf8 | 67.20 ns | 0.4243 ns | 0.3761 ns |       0 B |
```
After:
```ini
                    Method |     Mean |     Error |    StdDev | Allocated |
-------------------------- |---------:|----------:|----------:|----------:|
 DeserializeBadgeRankUtf16 | 51.34 ns | 0.0225 ns | 0.0175 ns |       0 B |
  DeserializeBadgeRankUtf8 | 51.42 ns | 0.4131 ns | 0.3864 ns |       0 B |
```