### PR TITLE
Change asp.net core formatter base classes

### DIFF
--- a/SpanJson.AspNetCore.Formatter.Tests/OutputFormatterTests.cs
+++ b/SpanJson.AspNetCore.Formatter.Tests/OutputFormatterTests.cs
@@ -61,7 +61,7 @@ namespace SpanJson.AspNetCore.Formatter.Tests
             var outputFormatterContext = GetOutputFormatterContext(model, modelType);
             var jsonFormatter = new SpanJsonOutputFormatter<TResolver>();
 
-            await jsonFormatter.WriteResponseBodyAsync(outputFormatterContext).ConfigureAwait(false);
+            await jsonFormatter.WriteAsync(outputFormatterContext).ConfigureAwait(false);
 
             using (var body = outputFormatterContext.HttpContext.Response.Body)
             {

--- a/SpanJson.AspNetCore.Formatter/SpanJsonInputFormatter.cs
+++ b/SpanJson.AspNetCore.Formatter/SpanJsonInputFormatter.cs
@@ -1,19 +1,21 @@
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace SpanJson.AspNetCore.Formatter
 {
-    public class SpanJsonInputFormatter<TResolver> : InputFormatter where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
+    public class SpanJsonInputFormatter<TResolver> : TextInputFormatter where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
     {
         public SpanJsonInputFormatter()
         {
             SupportedMediaTypes.Add("application/json");
             SupportedMediaTypes.Add("text/json");
             SupportedMediaTypes.Add("application/*+json");
+            SupportedEncodings.Add(UTF8EncodingWithoutBOM);
         }
 
-        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context)
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding encoding)
         {
             try
             {

--- a/SpanJson.AspNetCore.Formatter/SpanJsonOutputFormatter.cs
+++ b/SpanJson.AspNetCore.Formatter/SpanJsonOutputFormatter.cs
@@ -1,18 +1,20 @@
-﻿using System.Threading.Tasks;
+﻿using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Formatters;
 
 namespace SpanJson.AspNetCore.Formatter
 {
-    public class SpanJsonOutputFormatter<TResolver> : OutputFormatter where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
+    public class SpanJsonOutputFormatter<TResolver> : TextOutputFormatter where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
     {
         public SpanJsonOutputFormatter()
         {
             SupportedMediaTypes.Add("application/json");
             SupportedMediaTypes.Add("text/json");
             SupportedMediaTypes.Add("application/*+json");
+            SupportedEncodings.Add(Encoding.UTF8);
         }
 
-        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context)
+        public override Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding encoding)
         {
             if (context.Object != null)
             {


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/aspnet/core/web-api/advanced/custom-formatters?view=aspnetcore-2.1
the correct base classes are TextInputFormatter/TextOutputFormatter