### PR TITLE
Fix MultiByte Attribute Write

### DIFF
--- a/SpanJson.Tests/DictionaryTests.cs
+++ b/SpanJson.Tests/DictionaryTests.cs
@@ -100,5 +100,58 @@ namespace SpanJson.Tests
             Assert.NotNull(deserialized);
             Assert.Equal(dictionary, deserialized);
         }
+
+
+        [Fact]
+        public void SerializeDeserializeMultiByteKeyDictionaryUtf16()
+        {
+            var dictionary = new Dictionary<string, int>
+            {
+                {"Привет мир!0",0},
+                {"Привет мир!1",1},
+                {"Привет мир!2",2},
+                {"Привет мир!3",3},
+                {"Привет мир!4",4},
+                {"Привет мир!5",5},
+                {"Привет мир!6",6},
+                {"Привет мир!7",7},
+                {"Привет мир!8",8},
+                {"Привет мир!9",9},
+                {"Привет мир!10",10},
+                {"Привет мир!11",11},
+            };
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(dictionary);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<Dictionary<string, int>>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(dictionary, deserialized);
+        }
+
+
+        [Fact]
+        public void SerializeDeserializeMultiByteKeyDictionaryUtf8()
+        {
+            var dictionary = new Dictionary<string, int>
+            {
+                {"Привет мир!0",0},
+                {"Привет мир!1",1},
+                {"Привет мир!2",2},
+                {"Привет мир!3",3},
+                {"Привет мир!4",4},
+                {"Привет мир!5",5},
+                {"Привет мир!6",6},
+                {"Привет мир!7",7},
+                {"Привет мир!8",8},
+                {"Привет мир!9",9},
+                {"Привет мир!10",10},
+                {"Привет мир!11",11},
+            };
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(dictionary);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<Dictionary<string, int>>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(dictionary, deserialized);
+        }
+
     }
 }

--- a/SpanJson.Tests/JsonWriterTests.cs
+++ b/SpanJson.Tests/JsonWriterTests.cs
@@ -75,5 +75,39 @@ namespace SpanJson.Tests
             var output = writer.ToString();
             Assert.Equal(comparison, output);
         }
+
+        /// <summary>
+        /// This hits the resizing, otherwise the ascii case would hit array bounds
+        /// </summary>
+        [Theory]
+        [InlineData("칱칳칶칹칼캠츧", "{\"칱칳칶칹칼캠츧\":0}")]
+        [InlineData("Привет мир!0", "{\"Привет мир!0\":0}")]
+        public void WriteMultiCharNameUtf8Resizing(string name, string comparison)
+        {
+            var writer = new JsonWriter<byte>(16);
+            writer.WriteUtf8BeginObject();
+            writer.WriteUtf8Name(name);
+            writer.WriteUtf8Int32(0);
+            writer.WriteUtf8EndObject();
+            var output = writer.ToByteArray();
+            Assert.Equal(comparison, Encoding.UTF8.GetString(output));
+        }
+
+        /// <summary>
+        /// This hits the resizing, otherwise the ascii case would hit array bounds
+        /// </summary>
+        [Theory]
+        [InlineData("칱칳칶칹칼캠츧", "{\"칱칳칶칹칼캠츧\":0}")]
+        [InlineData("Привет мир!0", "{\"Привет мир!0\":0}")]
+        public void WriteMultiCharNameUtf16(string name, string comparison)
+        {
+            var writer = new JsonWriter<char>(32);
+            writer.WriteUtf16BeginObject();
+            writer.WriteUtf16Name(name);
+            writer.WriteUtf16Int32(0);
+            writer.WriteUtf16EndObject();
+            var output = writer.ToString();
+            Assert.Equal(comparison, output);
+        }
     }
 }

--- a/SpanJson/JsonWriter.Utf8.cs
+++ b/SpanJson/JsonWriter.Utf8.cs
@@ -471,7 +471,7 @@ namespace SpanJson
         public void WriteUtf8Name(in ReadOnlySpan<char> value)
         {
             ref var pos = ref _pos;
-            var sLength = Encoding.UTF8.GetByteCount(value) + 3;
+            var sLength = Encoding.UTF8.GetMaxByteCount(value.Length) + 3;
             if (pos > _bytes.Length - sLength)
             {
                 Grow(sLength);


### PR DESCRIPTION
WriteUtf8Name did not resize properly for multibyte char values.
WriteUtf8Name is used in Dictionary and Dynamic Serializers.