### PR TITLE
Fixed an issue in DateTimeParser where a negative offset would be incorrectly parsed when the minutes are non zero.

### DIFF
--- a/SpanJson.Tests/DateTests.cs
+++ b/SpanJson.Tests/DateTests.cs
@@ -36,7 +36,7 @@ namespace SpanJson.Tests
             Assert.True(DateTimeParser.TryParseDateTime(input.AsSpan(), out var dtValue, out var dtConsumed));
             Assert.Equal(length, dtConsumed);
             AssertDateTime(dtoValue.DateTime, year, month, day, hour, minute, second, fraction);
-            var offset = new TimeSpan(negative ? -offsethours : offsethours, offsetminutes, 0);
+            var offset = new TimeSpan(offsethours, offsetminutes, 0) * (negative ? -1 : 1);
             switch (kind)
             {
                 case DateTimeKind.Local:

--- a/SpanJson/Helpers/DateTimeParser.Utf16.cs
+++ b/SpanJson/Helpers/DateTimeParser.Utf16.cs
@@ -341,7 +341,11 @@ namespace SpanJson.Helpers
 
                 offsetMinutes = (int) (digit1 * 10 + digit2);
             }
-            offsetHours = offsetChar == '-' ? -offsetHours : offsetHours;
+            if (offsetChar == '-')
+            { 
+                offsetHours = -offsetHours;
+                offsetMinutes = -offsetMinutes;
+            }
             var timeSpan = new TimeSpan(offsetHours, offsetMinutes, 0);
             value = timeSpan == TimeSpan.Zero
                 ? new Date(year, month, day, hour, minute, second, fraction, DateTimeKind.Utc, timeSpan)

--- a/SpanJson/Helpers/DateTimeParser.Utf8.cs
+++ b/SpanJson/Helpers/DateTimeParser.Utf8.cs
@@ -342,7 +342,11 @@ namespace SpanJson.Helpers
 
                 offsetMinutes = (int) (digit1 * 10 + digit2);
             }
-            offsetHours = offsetChar == (byte) '-' ? -offsetHours : offsetHours;
+            if (offsetChar == (byte) '-')
+            { 
+                offsetHours = -offsetHours;
+                offsetMinutes = -offsetMinutes;
+            }
             var timeSpan = new TimeSpan(offsetHours, offsetMinutes, 0);
             value = timeSpan == TimeSpan.Zero
                 ? new Date(year, month, day, hour, minute, second, fraction, DateTimeKind.Utc, timeSpan)


### PR DESCRIPTION
This fixes #37. You actually had a test for negative offset with minutes, but the test also had the bug.