### PR TITLE
Add ToArrayPool methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,22 @@ See https://github.com/Tornhoof/SpanJson/wiki/Performance for Benchmarks
 ## How to use it ##
 ```csharp
 Synchronous API:
+
 var result = JsonSerializer.Generic.Utf16.Serialize(input);
 var result = JsonSerializer.NonGeneric.Utf16.Serialize(input);
 var result = JsonSerializer.Generic.Utf16.Deserialize<Input>(input);
 var result = JsonSerializer.NonGeneric.Utf16.Deserialize(input, typeof(Input));
+
 var result = JsonSerializer.Generic.Utf8.Serialize(input);
 var result = JsonSerializer.NonGeneric.Utf8.Serialize(input);
 var result = JsonSerializer.Generic.Utf8.Deserialize<Input>(input);
 var result = JsonSerializer.NonGeneric.Utf8.Deserialize(input, typeof(Input));
+
+// The following methods return an ArraySegment from the ArrayPool, you NEED to return it yourself after working with it.
+var result = JsonSerializer.Generic.Utf16.SerializeToArrayPool(input);
+var result = JsonSerializer.NonGeneric.Utf16.SerializeToArrayPool(input);
+var result = JsonSerializer.Generic.Utf8.SerializeToArrayPool(input);
+var result = JsonSerializer.NonGeneric.Utf8.SerializeToArrayPool(input);
 
 Asynchronous API:
 

--- a/SpanJson.Benchmarks/HelloWorldMessageBenchmark.cs
+++ b/SpanJson.Benchmarks/HelloWorldMessageBenchmark.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace SpanJson.Benchmarks
+{
+    [Config(typeof(MyConfig))]
+    public class HelloWorldMessageBenchmark
+    {
+        public struct JsonMessage
+        {
+            public string message { get; set; }
+        }
+
+        private static readonly JsonMessage Message = new JsonMessage {message = "Hello, World!"};
+
+
+        [Benchmark]
+        public string SerializeUtf16()
+        {
+            return JsonSerializer.Generic.Utf16.Serialize(Message);
+        }
+
+        [Benchmark]
+        public byte[] SerializeUtf8()
+        {
+            return JsonSerializer.Generic.Utf8.Serialize(Message);
+        }
+
+        [Benchmark]
+        public void SerializeUtf16Unsafe()
+        {
+            var buffer = JsonSerializer.Generic.Utf16.SerializeUnsafe(Message);
+            ArrayPool<char>.Shared.Return(buffer.Array);
+        }
+
+        [Benchmark]
+        public void SerializeUtf8Unsafe()
+        {
+            var buffer = JsonSerializer.Generic.Utf8.SerializeUnsafe(Message);
+            ArrayPool<byte>.Shared.Return(buffer.Array);
+        }
+
+        [Benchmark]
+        public ValueTask SerializeUtf16Async()
+        {
+            using (var tw = new StreamWriter(Stream.Null))
+            {
+                return JsonSerializer.Generic.Utf16.SerializeAsync(Message, tw);
+            }
+        }
+
+        [Benchmark]
+        public Task SerializeUtf8Async()
+        {
+            return JsonSerializer.Generic.Utf8.SerializeAsync(Message, Stream.Null).AsTask();
+        }
+    }
+}

--- a/SpanJson.Benchmarks/HelloWorldMessageBenchmark.cs
+++ b/SpanJson.Benchmarks/HelloWorldMessageBenchmark.cs
@@ -34,14 +34,14 @@ namespace SpanJson.Benchmarks
         [Benchmark]
         public void SerializeUtf16Unsafe()
         {
-            var buffer = JsonSerializer.Generic.Utf16.SerializeUnsafe(Message);
+            var buffer = JsonSerializer.Generic.Utf16.SerializeToArrayPool(Message);
             ArrayPool<char>.Shared.Return(buffer.Array);
         }
 
         [Benchmark]
         public void SerializeUtf8Unsafe()
         {
-            var buffer = JsonSerializer.Generic.Utf8.SerializeUnsafe(Message);
+            var buffer = JsonSerializer.Generic.Utf8.SerializeToArrayPool(Message);
             ArrayPool<byte>.Shared.Return(buffer.Array);
         }
 

--- a/SpanJson.Benchmarks/Program.cs
+++ b/SpanJson.Benchmarks/Program.cs
@@ -6,6 +6,9 @@ namespace SpanJson.Benchmarks
     {
         private static void Main(string[] args)
         {
+            var hwb = new HelloWorldMessageBenchmark();
+            hwb.SerializeUtf8Unsafe();
+            hwb.SerializeUtf8Unsafe();
             // dotnet run -c Release -- --methods=ReadUtf8Char
             var switcher = new BenchmarkSwitcher(typeof(Program).Assembly);
             switcher.Run(args);

--- a/SpanJson.Tests/ArrayPoolSerializerTests.cs
+++ b/SpanJson.Tests/ArrayPoolSerializerTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using SpanJson.Shared;
+using SpanJson.Shared.Fixture;
+using SpanJson.Shared.Models;
+using Xunit;
+
+namespace SpanJson.Tests
+{
+    public class ArrayPoolSerializerTests
+    {
+        private static readonly ExpressionTreeFixture Fixture = new ExpressionTreeFixture();
+
+        [Fact]
+        public void SerializeToArrayPoolUtf16()
+        {
+            var model = Fixture.Create<Answer>();
+            var serialized = JsonSerializer.Generic.Utf16.SerializeToArrayPool(model);
+            Assert.IsType<ArraySegment<char>>(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<Answer>(serialized.AsSpan(serialized.Offset, serialized.Count));
+            Assert.Equal(model, deserialized, GenericEqualityComparer.Default);
+            ArrayPool<char>.Shared.Return(serialized.Array);
+        }
+
+        [Fact]
+        public void SerializeToArrayPoolUtf8()
+        {
+            var model = Fixture.Create<Answer>();
+            var serialized = JsonSerializer.Generic.Utf8.SerializeToArrayPool(model);
+            Assert.IsType<ArraySegment<byte>>(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<Answer>(serialized.AsSpan(serialized.Offset, serialized.Count));
+            Assert.Equal(model, deserialized, GenericEqualityComparer.Default);
+            ArrayPool<byte>.Shared.Return(serialized.Array);
+        }
+
+        [Fact]
+        public void SerializeToArrayPoolNonGenericUtf16()
+        {
+            var model = Fixture.Create<Answer>();
+            var serialized = JsonSerializer.NonGeneric.Utf16.SerializeToArrayPool(model);
+            Assert.IsType<ArraySegment<char>>(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<Answer>(serialized.AsSpan(serialized.Offset, serialized.Count));
+            Assert.Equal(model, deserialized, GenericEqualityComparer.Default);
+            ArrayPool<char>.Shared.Return(serialized.Array);
+        }
+
+        [Fact]
+        public void SerializeToArrayPoolNonGenericUtf8()
+        {
+            var model = Fixture.Create<Answer>();
+            var serialized = JsonSerializer.NonGeneric.Utf8.SerializeToArrayPool(model);
+            Assert.IsType<ArraySegment<byte>>(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<Answer>(serialized.AsSpan(serialized.Offset, serialized.Count));
+            Assert.Equal(model, deserialized, GenericEqualityComparer.Default);
+            ArrayPool<byte>.Shared.Return(serialized.Array);
+        }
+    }
+}

--- a/SpanJson/JsonSerializer.Generics.cs
+++ b/SpanJson/JsonSerializer.Generics.cs
@@ -248,9 +248,9 @@ namespace SpanJson
                 /// <typeparam name="T">Type</typeparam>
                 /// <param name="input">Input</param>
                 /// <returns>Char array from ArrayPool</returns>
-                public static ArraySegment<char> SerializeUnsafe<T>(T input)
+                public static ArraySegment<char> SerializeToArrayPool<T>(T input)
                 {
-                    return SerializeUnsafe<T, ExcludeNullsOriginalCaseResolver<char>>(input);
+                    return SerializeToArrayPool<T, ExcludeNullsOriginalCaseResolver<char>>(input);
                 }
 
                 /// <summary>
@@ -275,7 +275,7 @@ namespace SpanJson
                 /// <typeparam name="TResolver">Resolver</typeparam>
                 /// <param name="input">Input</param>
                 /// <returns>String</returns>
-                public static ArraySegment<char> SerializeUnsafe<T, TResolver>(T input)
+                public static ArraySegment<char> SerializeToArrayPool<T, TResolver>(T input)
                     where TResolver : IJsonFormatterResolver<char, TResolver>, new()
                 {
                     return Inner<T, char, TResolver>.InnerSerializeToCharArrayPool(input);
@@ -408,9 +408,9 @@ namespace SpanJson
                 /// <typeparam name="T">Type</typeparam>
                 /// <param name="input">Input</param>
                 /// <returns>Byte array from ArrayPool</returns>
-                public static ArraySegment<byte> SerializeUnsafe<T>(T input)
+                public static ArraySegment<byte> SerializeToArrayPool<T>(T input)
                 {
-                    return SerializeUnsafe<T, ExcludeNullsOriginalCaseResolver<byte>>(input);
+                    return SerializeToArrayPool<T, ExcludeNullsOriginalCaseResolver<byte>>(input);
                 }
 
                 /// <summary>
@@ -475,14 +475,14 @@ namespace SpanJson
                 }
 
                 /// <summary>
-                ///     Serialize to byte array with specific resolver.
+                ///     Serialize to byte array from array pool with specific resolver.
                 ///     The returned ArraySegment's Array needs to be returned to the ArrayPool
                 /// </summary>
                 /// <typeparam name="T">Type</typeparam>
                 /// <typeparam name="TResolver">Resolver</typeparam>
                 /// <param name="input">Input</param>
                 /// <returns>Byte array from ArrayPool</returns>
-                public static ArraySegment<byte> SerializeUnsafe<T, TResolver>(T input)
+                public static ArraySegment<byte> SerializeToArrayPool<T, TResolver>(T input)
                     where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
                 {
                     return Inner<T, byte, TResolver>.InnerSerializeToByteArrayPool(input);

--- a/SpanJson/JsonSerializer.Generics.cs
+++ b/SpanJson/JsonSerializer.Generics.cs
@@ -46,7 +46,7 @@ namespace SpanJson
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
-                    _lastSerializationSize = jsonWriter.Position;
+                    _lastSerializationSize = jsonWriter.Data.Length;
                     var temp = jsonWriter.Data;
                     var data = Unsafe.As<TSymbol[], char[]>(ref temp);
                     var result = new ArraySegment<char>(data, 0, jsonWriter.Position);
@@ -57,7 +57,7 @@ namespace SpanJson
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
-                    _lastSerializationSize = jsonWriter.Position;
+                    _lastSerializationSize = jsonWriter.Data.Length;
                     var result = jsonWriter.ToByteArray();
                     return result;
                 }
@@ -67,7 +67,7 @@ namespace SpanJson
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
-                    _lastSerializationSize = jsonWriter.Position * 2;
+                    _lastSerializationSize = jsonWriter.Data.Length;
                     var temp = jsonWriter.Data;
                     var data = Unsafe.As<TSymbol[], byte[]>(ref temp);
                     var result = new ArraySegment<byte>(data, 0, jsonWriter.Position);
@@ -78,11 +78,10 @@ namespace SpanJson
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
-                    var newSize = jsonWriter.Position;
-                    _lastSerializationSize = newSize;
+                    _lastSerializationSize = jsonWriter.Data.Length;
                     var temp = jsonWriter.Data;
                     var data = Unsafe.As<TSymbol[], char[]>(ref temp);
-                    var result = writer.WriteAsync(data, 0, newSize);
+                    var result = writer.WriteAsync(data, 0, jsonWriter.Position);
                     if (result.IsCompletedSuccessfully)
                     {
                         // This is a bit ugly, as we use the arraypool outside of the jsonwriter, but ref can't be use in async
@@ -97,11 +96,10 @@ namespace SpanJson
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
-                    var newSize = jsonWriter.Position;
-                    _lastSerializationSize = newSize;
+                    _lastSerializationSize = jsonWriter.Data.Length;
                     var temp = jsonWriter.Data;
                     var data = Unsafe.As<TSymbol[], byte[]>(ref temp);
-                    var result = stream.WriteAsync(data, 0, newSize, cancellationToken);
+                    var result = stream.WriteAsync(data, 0, jsonWriter.Position, cancellationToken);
                     if (result.IsCompletedSuccessfully)
                     {
                         // This is a bit ugly, as we use the arraypool outside of the jsonwriter, but ref can't be use in async

--- a/SpanJson/JsonSerializer.Generics.cs
+++ b/SpanJson/JsonSerializer.Generics.cs
@@ -42,12 +42,35 @@ namespace SpanJson
                     return result;
                 }
 
+                public static ArraySegment<char> InnerSerializeToCharArrayPool(T input)
+                {
+                    var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
+                    Formatter.Serialize(ref jsonWriter, input, 0);
+                    _lastSerializationSize = jsonWriter.Position;
+                    var temp = jsonWriter.Data;
+                    var data = Unsafe.As<TSymbol[], char[]>(ref temp);
+                    var result = new ArraySegment<char>(data, 0, jsonWriter.Position);
+                    return result;
+                }
+
                 public static byte[] InnerSerializeToByteArray(T input)
                 {
                     var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
                     Formatter.Serialize(ref jsonWriter, input, 0);
                     _lastSerializationSize = jsonWriter.Position;
                     var result = jsonWriter.ToByteArray();
+                    return result;
+                }
+
+
+                public static ArraySegment<byte> InnerSerializeToByteArrayPool(T input)
+                {
+                    var jsonWriter = new JsonWriter<TSymbol>(_lastSerializationSize);
+                    Formatter.Serialize(ref jsonWriter, input, 0);
+                    _lastSerializationSize = jsonWriter.Position * 2;
+                    var temp = jsonWriter.Data;
+                    var data = Unsafe.As<TSymbol[], byte[]>(ref temp);
+                    var result = new ArraySegment<byte>(data, 0, jsonWriter.Position);
                     return result;
                 }
 
@@ -221,6 +244,18 @@ namespace SpanJson
                 }
 
                 /// <summary>
+                ///     Serialize to char buffer from ArrayPool
+                ///     The returned ArraySegment's Array needs to be returned to the ArrayPool
+                /// </summary>
+                /// <typeparam name="T">Type</typeparam>
+                /// <param name="input">Input</param>
+                /// <returns>Char array from ArrayPool</returns>
+                public static ArraySegment<char> SerializeUnsafe<T>(T input)
+                {
+                    return SerializeUnsafe<T, ExcludeNullsOriginalCaseResolver<char>>(input);
+                }
+
+                /// <summary>
                 ///     Serialize to string with specific resolver.
                 /// </summary>
                 /// <typeparam name="T">Type</typeparam>
@@ -231,6 +266,21 @@ namespace SpanJson
                     where TResolver : IJsonFormatterResolver<char, TResolver>, new()
                 {
                     return Inner<T, char, TResolver>.InnerSerializeToString(input);
+                }
+
+
+                /// <summary>
+                ///     Serialize to string with specific resolver.
+                ///     The returned ArraySegment's Array needs to be returned to the ArrayPool
+                /// </summary>
+                /// <typeparam name="T">Type</typeparam>
+                /// <typeparam name="TResolver">Resolver</typeparam>
+                /// <param name="input">Input</param>
+                /// <returns>String</returns>
+                public static ArraySegment<char> SerializeUnsafe<T, TResolver>(T input)
+                    where TResolver : IJsonFormatterResolver<char, TResolver>, new()
+                {
+                    return Inner<T, char, TResolver>.InnerSerializeToCharArrayPool(input);
                 }
 
                 /// <summary>
@@ -354,6 +404,18 @@ namespace SpanJson
                 }
 
                 /// <summary>
+                ///     Serialize to byte array from ArrayPool.
+                ///     The returned ArraySegment's Array needs to be returned to the ArrayPool
+                /// </summary>
+                /// <typeparam name="T">Type</typeparam>
+                /// <param name="input">Input</param>
+                /// <returns>Byte array from ArrayPool</returns>
+                public static ArraySegment<byte> SerializeUnsafe<T>(T input)
+                {
+                    return SerializeUnsafe<T, ExcludeNullsOriginalCaseResolver<byte>>(input);
+                }
+
+                /// <summary>
                 ///     Deserialize from byte array.
                 /// </summary>
                 /// <typeparam name="T">Type</typeparam>
@@ -412,6 +474,20 @@ namespace SpanJson
                     where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
                 {
                     return Inner<T, byte, TResolver>.InnerSerializeToByteArray(input);
+                }
+
+                /// <summary>
+                ///     Serialize to byte array with specific resolver.
+                ///     The returned ArraySegment's Array needs to be returned to the ArrayPool
+                /// </summary>
+                /// <typeparam name="T">Type</typeparam>
+                /// <typeparam name="TResolver">Resolver</typeparam>
+                /// <param name="input">Input</param>
+                /// <returns>Byte array from ArrayPool</returns>
+                public static ArraySegment<byte> SerializeUnsafe<T, TResolver>(T input)
+                    where TResolver : IJsonFormatterResolver<byte, TResolver>, new()
+                {
+                    return Inner<T, byte, TResolver>.InnerSerializeToByteArrayPool(input);
                 }
 
                 /// <summary>


### PR DESCRIPTION
Add SerializeToArrayPool methods to directly return the arraypool to the caller.
Change the last serialization size estimate logic.
This solves #44  and #43 