### PR TITLE
Fix ExpandoObject

### DIFF
--- a/SpanJson.Tests/DynamicTests.cs
+++ b/SpanJson.Tests/DynamicTests.cs
@@ -153,8 +153,8 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DynamicObjectWithKnownMembers>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal(5, (int) dynamicObject.Value);
-            var supported = (List<string>) dynamicObject.Supported;
+            Assert.Equal(5, (int)deserialized.Value);
+            var supported = (List<string>)deserialized.Supported;
             Assert.NotEmpty(supported);
             Assert.Equal(list, supported);
         }
@@ -163,17 +163,17 @@ namespace SpanJson.Tests
         [Fact]
         public void DynamicObjectWithKnownMembersNoDynamicUtf8()
         {
-            var list = new List<string> { "Hello", "World" };
+            var list = new List<string> {"Hello", "World"};
             dynamic dynamicObject = new DynamicObjectWithKnownMembers();
             dynamicObject.Value = 5;
-            dynamicObject.Supported = new List<string> { "Hello", "World" };
+            dynamicObject.Supported = new List<string> {"Hello", "World"};
 
             var serialized = JsonSerializer.Generic.Utf8.Serialize(dynamicObject);
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DynamicObjectWithKnownMembers>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal(5, (int) dynamicObject.Value);
-            var supported = (List<string>)dynamicObject.Supported;
+            Assert.Equal(5, (int) deserialized.Value);
+            var supported = (List<string>) deserialized.Supported;
             Assert.NotEmpty(supported);
             Assert.Equal(list, supported);
         }
@@ -191,11 +191,11 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DynamicObjectWithKnownMembers>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal(5, (int) dynamicObject.Value);
-            var supported = (List<string>) dynamicObject.Supported;
+            Assert.Equal(5, (int)deserialized.Value);
+            var supported = (List<string>)deserialized.Supported;
             Assert.NotEmpty(supported);
             Assert.Equal(list, supported);
-            Assert.Equal("Hello World", (string) dynamicObject.Text);
+            Assert.Equal("Hello World", (string)deserialized.Text);
         }
 
 
@@ -212,11 +212,64 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DynamicObjectWithKnownMembers>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal(5, (int)dynamicObject.Value);
-            var supported = (List<string>)dynamicObject.Supported;
+            Assert.Equal(5, (int)deserialized.Value);
+            var supported = (List<string>)deserialized.Supported;
             Assert.NotEmpty(supported);
             Assert.Equal(list, supported);
-            Assert.Equal("Hello World", (string)dynamicObject.Text);
+            Assert.Equal("Hello World", (string)deserialized.Text);
+        }
+
+        [Fact]
+        public void DynamicObjectWithKnownMembersUtf16CamelCase()
+        {
+            var list = new List<string> { "Hello", "World" };
+            dynamic dynamicObject = new DynamicObjectWithKnownMembers();
+            dynamicObject.Value = 5;
+            dynamicObject.Text = "Hello World";
+            dynamicObject.Supported = list;
+            dynamicObject.DynamicValue = "Hello Universe";
+
+            var serialized = JsonSerializer.Generic.Utf16.Serialize< DynamicObjectWithKnownMembers, ExcludeNullsCamelCaseResolver<char>>(dynamicObject);
+            Assert.NotNull(serialized);
+            Assert.Contains("\"text\":", serialized);
+            Assert.Contains("\"value\":", serialized);
+            Assert.Contains("\"supported\":", serialized);
+            Assert.Contains("\"dynamicValue\":", serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DynamicObjectWithKnownMembers, ExcludeNullsCamelCaseResolver<char>>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(5, (int)deserialized.Value);
+            var supported = (List<string>)deserialized.Supported;
+            Assert.NotEmpty(supported);
+            Assert.Equal(list, supported);
+            Assert.Equal("Hello World", (string)deserialized.text);
+            Assert.Equal("Hello Universe", (string)deserialized.dynamicValue);
+        }
+
+
+        [Fact]
+        public void DynamicObjectWithKnownMembersUtf8CamelCase()
+        {
+            var list = new List<string> { "Hello", "World" };
+            dynamic dynamicObject = new DynamicObjectWithKnownMembers();
+            dynamicObject.Value = 5;
+            dynamicObject.Text = "Hello World";
+            dynamicObject.Supported = list;
+            dynamicObject.DynamicValue = "Hello Universe";
+            var serialized = JsonSerializer.Generic.Utf8.Serialize<DynamicObjectWithKnownMembers, ExcludeNullsCamelCaseResolver<byte>>(dynamicObject);
+            Assert.NotNull(serialized);
+            var serializedText = Encoding.UTF8.GetString(serialized);
+            Assert.Contains("\"text\":", serializedText);
+            Assert.Contains("\"value\":", serializedText);
+            Assert.Contains("\"supported\":", serializedText);
+            Assert.Contains("\"dynamicValue\":", serializedText);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DynamicObjectWithKnownMembers, ExcludeNullsCamelCaseResolver<byte>>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(5, (int)deserialized.Value);
+            var supported = (List<string>)deserialized.Supported;
+            Assert.NotEmpty(supported);
+            Assert.Equal(list, supported);
+            Assert.Equal("Hello World", (string)deserialized.text);
+            Assert.Equal("Hello Universe", (string)deserialized.dynamicValue);
         }
 
         [Fact]
@@ -257,7 +310,7 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<dynamic>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal("Hello World", (string) dynamicObject.Text);
+            Assert.Equal("Hello World", (string)deserialized.Text);
         }
 
 
@@ -271,7 +324,7 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf8.Deserialize<dynamic>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal("Hello World", (string) dynamicObject.Text);
+            Assert.Equal("Hello World", (string)deserialized.Text);
         }
 
 
@@ -286,7 +339,7 @@ namespace SpanJson.Tests
                 Assert.NotNull(serialized);
                 var deserialized = JsonSerializer.Generic.Utf16.Deserialize<dynamic>(serialized);
                 Assert.NotNull(deserialized);
-                Assert.Equal("Hello World", (string) dynamicObject.Text);
+                Assert.Equal("Hello World", (string)deserialized.Text);
             }
         }
 
@@ -301,7 +354,7 @@ namespace SpanJson.Tests
             {
                 var deserialized = JSON.DeserializeDynamic(serialized);
                 Assert.NotNull(deserialized);
-                Assert.Equal("Hello World", (string) dynamicObject.Text);
+                Assert.Equal("Hello World", (string)deserialized.Text);
             }
         }
 
@@ -316,14 +369,46 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<dynamic>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal("Hello World", (string) dynamicObject.Text);
-            Assert.Equal(5, (int) dynamicObject.Value);
+            Assert.Equal("Hello World", (string)deserialized.Text);
+            Assert.Equal(5, (int)deserialized.Value);
+        }
+
+
+        [Fact]
+        public void ExpandoUtf16()
+        {
+            dynamic dynamicObject = new MyDynamicObject();
+            dynamicObject.Text = "Hello World";
+            dynamicObject.Value = 5;
+            dynamicObject.Array = new string[] { "Hello", "World" };
+
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(dynamicObject);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<dynamic>(serialized);
+            var serialized2 = JsonSerializer.Generic.Utf16.Serialize(deserialized);
+            Assert.Equal(serialized, serialized2);
+
+        }
+
+        [Fact]
+        public void ExpandoUtf8()
+        {
+            dynamic dynamicObject = new ExpandoObject();
+            dynamicObject.Text = "Hello World";
+            dynamicObject.Value = 5;
+            dynamicObject.Array = new string[] { "Hello", "World" };
+
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(dynamicObject);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<dynamic>(serialized);
+            var serialized2 = JsonSerializer.Generic.Utf8.Serialize(deserialized);
+            Assert.Equal(serialized, serialized2);
         }
 
         [Fact]
         public void DynamicObjectSerializeTwice()
         {
-            dynamic dynamicObject = new MyDynamicObject();
+            dynamic dynamicObject = new ExpandoObject();
             dynamicObject.Text = "Hello World";
             dynamicObject.Value = 5;
             dynamicObject.Array = new string[] {"Hello", "World"};
@@ -378,8 +463,8 @@ namespace SpanJson.Tests
             Assert.Contains("null", serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<MyDynamicObject, IncludeNullsOriginalCaseResolver<char>>(serialized);
             Assert.NotNull(deserialized);
-            Assert.Equal("Hello World", (string) dynamicObject.Text);
-            Assert.Equal(5, (int) dynamicObject.Value);
+            Assert.Equal("Hello World", (string)deserialized.Text);
+            Assert.Equal(5, (int)deserialized.Value);
             Assert.Null(deserialized.NullValue);
         }
 

--- a/SpanJson/Formatters/Dynamic/ISpanJsonDynamicArray.cs
+++ b/SpanJson/Formatters/Dynamic/ISpanJsonDynamicArray.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace SpanJson.Formatters.Dynamic
+{
+    public interface ISpanJsonDynamicArray : IEnumerable<object>
+    {
+
+    }
+}

--- a/SpanJson/Formatters/Dynamic/SpanJsonDynamic.cs
+++ b/SpanJson/Formatters/Dynamic/SpanJsonDynamic.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Dynamic;
 using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Text;
 
 namespace SpanJson.Formatters.Dynamic
@@ -12,6 +13,7 @@ namespace SpanJson.Formatters.Dynamic
             Symbols = span.ToArray();
         }
 
+        [IgnoreDataMember]
         public TSymbol[] Symbols { get; }
 
         protected abstract BaseDynamicTypeConverter<TSymbol> Converter { get; }

--- a/SpanJson/Formatters/Dynamic/SpanJsonDynamicArray.cs
+++ b/SpanJson/Formatters/Dynamic/SpanJsonDynamicArray.cs
@@ -6,10 +6,11 @@ using System.ComponentModel;
 using System.Dynamic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.Serialization;
 
 namespace SpanJson.Formatters.Dynamic
 {
-    public sealed class SpanJsonDynamicArray<TSymbol> : DynamicObject, IEnumerable<object> where TSymbol : struct
+    public sealed class SpanJsonDynamicArray<TSymbol> : DynamicObject, ISpanJsonDynamicArray where TSymbol : struct
     {
         private static readonly ConcurrentDictionary<Type, Func<object[], ICountableEnumerable>> Enumerables =
             new ConcurrentDictionary<Type, Func<object[], ICountableEnumerable>>();
@@ -21,8 +22,9 @@ namespace SpanJson.Formatters.Dynamic
             _input = input;
         }
 
+        [IgnoreDataMember]
         public object this[int index] => _input[index];
-
+        [IgnoreDataMember]
         public int Length => _input.Length;
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/SpanJson/Resolvers/ResolverBase.cs
+++ b/SpanJson/Resolvers/ResolverBase.cs
@@ -273,6 +273,11 @@ namespace SpanJson.Resolvers
                 }
             }
 
+            if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type))
+            {
+                return GetDefaultOrCreate(typeof(DynamicMetaObjectProviderFormatter<,,>).MakeGenericType(type, typeof(TSymbol), typeof(TResolver)));
+            }
+
             if (type.TryGetTypeOfGenericInterface(typeof(IDictionary<,>), out var dictArgumentTypes) && !IsBadDictionary(type))
             {
                 if (dictArgumentTypes.Length != 2 || dictArgumentTypes[0] != typeof(string))
@@ -303,11 +308,6 @@ namespace SpanJson.Resolvers
             {
                 return GetDefaultOrCreate(
                     typeof(EnumerableFormatter<,,,>).MakeGenericType(type, enumArgumentTypes.Single(), typeof(TSymbol), typeof(TResolver)));
-            }
-
-            if (typeof(IDynamicMetaObjectProvider).IsAssignableFrom(type))
-            {
-                return GetDefaultOrCreate(typeof(DynamicMetaObjectProviderFormatter<,,>).MakeGenericType(type, typeof(TSymbol), typeof(TResolver)));
             }
 
             if (type.TryGetNullableUnderlyingType(out var underlyingType))


### PR DESCRIPTION
The tests  didn't test ExpandoObject, it implements IDictionary and we evaluated IDictionary before IDynamicMetaDataProvider, which is the wrong oder.
This fixes this.