### PR TITLE
Diverse enum fixes for duplicate values and a bit of readonlyspan for static arrays

### DIFF
--- a/SpanJson.Tests/EnumIntegerTests.cs
+++ b/SpanJson.Tests/EnumIntegerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
+using Newtonsoft.Json;
 using SpanJson.Resolvers;
 using Xunit;
 
@@ -20,14 +21,6 @@ namespace SpanJson.Tests
             Min = long.MinValue,
             None = 0,
             Max = long.MaxValue,
-        }
-
-        [Flags]
-        public enum FlagEnum
-        {
-            First = 1,
-            Second = 2,
-            Third = 4
         }
 
         public enum DuplicateEnum
@@ -85,30 +78,7 @@ namespace SpanJson.Tests
             Assert.Equal(value, deserialized);
         }
 
-        [Theory]
-        [InlineData(FlagEnum.First)]
-        [InlineData(FlagEnum.First | FlagEnum.Second)]
-        [InlineData(FlagEnum.First | FlagEnum.Second | FlagEnum.Third)]
-        public void SerializeDeserializeFlagsUtf16(FlagEnum value)
-        {
-            var serialized = JsonSerializer.Generic.Utf16.Serialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
-            Assert.NotNull(serialized);
-            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
-            Assert.Equal(value, deserialized);
-        }
 
-
-        [Theory]
-        [InlineData(FlagEnum.First)]
-        [InlineData(FlagEnum.First | FlagEnum.Second)]
-        [InlineData(FlagEnum.First | FlagEnum.Second | FlagEnum.Third)]
-        public void SerializeDeserializeFlagsUtf8(FlagEnum value)
-        {
-            var serialized = JsonSerializer.Generic.Utf8.Serialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(value);
-            Assert.NotNull(serialized);
-            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(serialized);
-            Assert.Equal(value, deserialized);
-        }
 
         [Theory]
         [InlineData(DuplicateEnum.First)]
@@ -129,6 +99,94 @@ namespace SpanJson.Tests
             var serialized = JsonSerializer.Generic.Utf16.Serialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Flags]
+        public enum FlagsEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 4
+        }
+
+
+        [Flags]
+        public enum DuplicateFlagsEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 2
+        }
+
+
+        [Theory]
+        [InlineData(DuplicateFlagsEnum.First)]
+        [InlineData(DuplicateFlagsEnum.First | DuplicateFlagsEnum.Second)]
+        public void SerializeDeserializeDuplicateFlagsUtf16(DuplicateFlagsEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+
+        [Theory]
+        [InlineData(DuplicateFlagsEnum.First)]
+        [InlineData(DuplicateFlagsEnum.First | DuplicateFlagsEnum.Second)]
+        public void SerializeDeserializeDuplicateFlagsUtf8(DuplicateFlagsEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+
+        [Theory]
+        [InlineData(FlagsEnum.First)]
+        [InlineData(FlagsEnum.First | FlagsEnum.Second)]
+        [InlineData(FlagsEnum.First | FlagsEnum.Second | FlagsEnum.Third)]
+        public void SerializeDeserializeFlagsUtf16(FlagsEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize<FlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<FlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+
+        [Theory]
+        [InlineData(FlagsEnum.First)]
+        [InlineData(FlagsEnum.First | FlagsEnum.Second)]
+        [InlineData(FlagsEnum.First | FlagsEnum.Second | FlagsEnum.Third)]
+        public void SerializeDeserializeFlagsUtf8(FlagsEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize<FlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<FlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(serialized);
+            Assert.Equal(value, deserialized);
+
+        }
+
+        [Fact]
+        public void SerializeDeserializeDuplicateUtf16Manual()
+        {
+            var value = DuplicateEnum.Third;
+            var serialized = JsonSerializer.Generic.Utf16.Serialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Fact]
+        public void SerializeDeserializeDuplicateFlagsUtf16Manual()
+        {
+            var value = DuplicateFlagsEnum.First | DuplicateFlagsEnum.Second | DuplicateFlagsEnum.Third;
+            var serialized = JsonSerializer.Generic.Utf16.Serialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateFlagsEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
             Assert.Equal(value, deserialized);
         }
     }

--- a/SpanJson.Tests/EnumIntegerTests.cs
+++ b/SpanJson.Tests/EnumIntegerTests.cs
@@ -30,6 +30,13 @@ namespace SpanJson.Tests
             Third = 4
         }
 
+        public enum DuplicateEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 1,
+        }
+
         [Theory]
         [InlineData(TestEnum.Hello)]
         [InlineData(TestEnum.None)]
@@ -100,6 +107,28 @@ namespace SpanJson.Tests
             var serialized = JsonSerializer.Generic.Utf8.Serialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(value);
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf8.Deserialize<FlagEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Theory]
+        [InlineData(DuplicateEnum.First)]
+        [InlineData(DuplicateEnum.Second)]
+        public void SerializeDeserializeDuplicateUtf8(DuplicateEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<byte>>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Theory]
+        [InlineData(DuplicateEnum.First)]
+        [InlineData(DuplicateEnum.Second)]
+        public void SerializeDeserializeDuplicateUtf16(DuplicateEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum, ExcludeNullCamelCaseIntegerEnumResolver<char>>(serialized);
             Assert.Equal(value, deserialized);
         }
     }

--- a/SpanJson.Tests/EnumStringTests.cs
+++ b/SpanJson.Tests/EnumStringTests.cs
@@ -25,6 +25,13 @@ namespace SpanJson.Tests
             Fourth = 8,
         }
 
+        public enum DuplicateEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 1,
+        }
+
         [Theory]
         [InlineData(TestEnum.Hello, "\"Hello\"")]
         [InlineData(TestEnum.World, "\"World\"")]
@@ -70,6 +77,28 @@ namespace SpanJson.Tests
             var serialized = JsonSerializer.Generic.Utf16.Serialize(value);
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<TestEnum>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Theory]
+        [InlineData(DuplicateEnum.First)]
+        [InlineData(DuplicateEnum.Second)]
+        public void SerializeDeserializeDuplicateUtf8(DuplicateEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<DuplicateEnum>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Theory]
+        [InlineData(DuplicateEnum.First)]
+        [InlineData(DuplicateEnum.Second)]
+        public void SerializeDeserializeDuplicateUtf16(DuplicateEnum value)
+        {
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum>(serialized);
             Assert.Equal(value, deserialized);
         }
 

--- a/SpanJson.Tests/EnumStringTests.cs
+++ b/SpanJson.Tests/EnumStringTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using System.Text;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using SpanJson.Resolvers;
 using Xunit;
 
@@ -26,6 +28,14 @@ namespace SpanJson.Tests
         }
 
         public enum DuplicateEnum
+        {
+            First = 1,
+            Second = 2,
+            Third = 1,
+        }
+
+        [Flags]
+        public enum DuplicateFlagsEnum
         {
             First = 1,
             Second = 2,
@@ -100,6 +110,33 @@ namespace SpanJson.Tests
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum>(serialized);
             Assert.Equal(value, deserialized);
+        }
+
+        [Fact]
+        public void SerializeDeserializeDuplicateUtf16Manual()
+        {
+            var value = DuplicateEnum.Third;
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateEnum>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Fact]
+        public void SerializeDeserializeDuplicateFlagsUtf16Manual()
+        {
+            var value = DuplicateFlagsEnum.First | DuplicateFlagsEnum.Second | DuplicateFlagsEnum.Third;
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(value);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<DuplicateFlagsEnum>(serialized);
+            Assert.Equal(value, deserialized);
+        }
+
+        [Fact]
+        public void SerializeDeserializeDuplicateFlagsUtf16NotFound()
+        {
+            string value = "\"   First, Second   , Third, Unknown  \"";
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Generic.Utf16.Deserialize<DuplicateFlagsEnum>(value));
         }
 
         [Fact]

--- a/SpanJson/Formatters/EnumStringFlagsFormatter.cs
+++ b/SpanJson/Formatters/EnumStringFlagsFormatter.cs
@@ -100,11 +100,12 @@ namespace SpanJson.Formatters
 
         private static T[] BuildFlags()
         {
-            var values = Enum.GetValues(typeof(T));
-            var result = new T[values.Length];
-            for (var i = 0; i < values.Length; i++)
+            var names = Enum.GetNames(typeof(T));
+            var result = new T[names.Length];
+            for (var i = 0; i < names.Length; i++)
             {
-                result[i] = (T) values.GetValue(i);
+                var value = Enum.Parse(typeof(T), names[i]);
+                result[i] = (T) value;
             }
 
             return result;

--- a/SpanJson/JsonConstants.cs
+++ b/SpanJson/JsonConstants.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 
 namespace SpanJson
 {
@@ -24,9 +25,8 @@ namespace SpanJson
         public const byte True = (byte) 't';
         public const byte ValueSeparator = (byte) ',';
 
-        public static readonly byte[] NewLine = Encoding.UTF8.GetBytes("\r\n");
-
-        public static readonly byte[] NullTerminator = {0};
+        public static ReadOnlySpan<byte> NewLine => new[] {(byte) '\r', (byte) '\n'};
+        public static ReadOnlySpan<byte> NullTerminator => new byte[] {0};
     }
 
     public static class JsonUtf16Constant
@@ -45,8 +45,7 @@ namespace SpanJson
         public const char True = 't';
         public const char ValueSeparator = ',';
 
-        public static readonly char[] NewLine = {'\r', '\n'};
-
-        public static readonly char[] NullTerminator = {'\0'};
+        public static ReadOnlySpan<char> NewLine => new[] {'\r', '\n'};
+        public static ReadOnlySpan<char> NullTerminator => new[] {'\0'};
     }
 }

--- a/SpanJson/JsonConstants.cs
+++ b/SpanJson/JsonConstants.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 
 namespace SpanJson
 {


### PR DESCRIPTION
Diverse enum fixes for duplicate values and a bit of readonlyspan for static arrays