### PR TITLE
Added test to check serialization of escaped non-latin strings as enum values.

### DIFF
--- a/SpanJson.Tests/NonLatinEnumDataMemberTests.cs
+++ b/SpanJson.Tests/NonLatinEnumDataMemberTests.cs
@@ -1,0 +1,76 @@
+﻿using System.Runtime.Serialization;
+using System.Text;
+using Xunit;
+
+namespace SpanJson.Tests
+{
+    public class NonLatinEnumDataMemberTests
+    {
+        [Fact]
+        public void Utf8CanSerializeEnumsWithNonLatinValueInEnumMemberAnnotations()
+        {
+            var input = new StatusContainer
+            {
+                Status = Status.Busy,
+            };
+
+            var serialized = JsonSerializer.Generic.Utf8.Serialize(input);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<StatusContainer>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(input.Status, deserialized.Status);
+        }
+
+        [Fact]
+        public void Utf16CanSerializeEnumsWithNonLatinValueInEnumMemberAnnotations()
+        {
+            var input = new StatusContainer
+            {
+                Status = Status.Busy,
+            };
+
+            var serialized = JsonSerializer.Generic.Utf16.Serialize(input);
+            Assert.NotNull(serialized);
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<StatusContainer>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(input.Status, deserialized.Status);
+        }
+
+        [Fact]
+        public void Utf8CanDeserializeEnumsWithNonLatinValueInEnumMemberAnnotations()
+        {
+            var serialized = "{\"status\":\"\u0441\u0432\u043e\u0431\u043e\u0434\u043d\u044b\"}";
+
+            var serializedUtf8 = Encoding.UTF8.GetBytes(serialized);
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<StatusContainer>(serializedUtf8);
+            Assert.NotNull(deserialized);
+            Assert.Equal(Status.Free, deserialized.Status);
+        }
+
+        [Fact]
+        public void Utf16CanDeserializeEnumsWithNonLatinValueInEnumMemberAnnotations()
+        {
+            var serialized = "{\"status\":\"\u0441\u0432\u043e\u0431\u043e\u0434\u043d\u044b\"}";
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<StatusContainer>(serialized);
+            Assert.NotNull(deserialized);
+            Assert.Equal(Status.Free, deserialized.Status);
+        }
+
+        [DataContract]
+        public class StatusContainer
+        {
+            [DataMember]
+            public Status Status { get; set; }
+        }
+
+
+        [DataContract]
+        public enum Status
+        {
+            [EnumMember(Value = "заняты")]
+            Busy,
+            [EnumMember(Value = "свободны")]
+            Free,
+        }
+    }
+}


### PR DESCRIPTION
Hi, @Tornhoof.

Could you please have a look at additional tests? I've expected deserializer to work for non-latin strings escaped in source `JSON` in `Utf8CanDeserializeEnumsWithNonLatinValueInEnumMemberAnnotations` and `Utf16CanDeserializeEnumsWithNonLatinValueInEnumMemberAnnotations`.
Original I have `UTF8` encoded file with escaped enums which I only able to deserialize specifying custom `JsonCustomSerializerAttribute` on property. BTW, it's not possible to annotate enum with `JsonCustomSerializerAttribute`, which is probably also minor bug in [attribute definition](https://github.com/Tornhoof/SpanJson/blob/2c8478ca8f486d705f79b902cee667c017f9d38f/SpanJson/JsonCustomSerializerAttribute.cs#L10), where `AttributeTargets.Enum` is missing.

Thanks!