### PR TITLE
Bugfixes wrt to pretty printed json

### DIFF
--- a/SpanJson.AspNetCore.Formatter.Tests/WebTests.cs
+++ b/SpanJson.AspNetCore.Formatter.Tests/WebTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -33,7 +34,29 @@ namespace SpanJson.AspNetCore.Formatter.Tests
                 {
                     Assert.True(response.IsSuccessStatusCode);
                     var body = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
-                    var text = Encoding.UTF8.GetString(body);
+                    var resultModel = JsonSerializer.Generic.Utf8.Deserialize<TestObject, AspNetCoreDefaultResolver<byte>>(body);
+                    Assert.Equal(model, resultModel);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PingPongLarge()
+        {
+            var uri = new UriBuilder(_fixture.BaseAddress) { Path = "api/test/PingPong" };
+            var fixture = new ExpressionTreeFixture();
+            var model = fixture.Create<TestObject>();
+            model.Hello = string.Join(", ", Enumerable.Repeat("Hello", 10000));
+            model.World = string.Join(", ", Enumerable.Repeat("World", 10000));
+            using (var message = new HttpRequestMessage(HttpMethod.Post, uri.Uri))
+            {
+                message.Content = new ByteArrayContent(JsonSerializer.Generic.Utf8.Serialize<TestObject, AspNetCoreDefaultResolver<byte>>(model));
+                message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+
+                using (var response = await _fixture.Client.SendAsync(message).ConfigureAwait(false))
+                {
+                    Assert.True(response.IsSuccessStatusCode);
+                    var body = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
                     var resultModel = JsonSerializer.Generic.Utf8.Deserialize<TestObject, AspNetCoreDefaultResolver<byte>>(body);
                     Assert.Equal(model, resultModel);
                 }

--- a/SpanJson.AspNetCore.Formatter/SpanJsonOutputFormatter.cs
+++ b/SpanJson.AspNetCore.Formatter/SpanJsonOutputFormatter.cs
@@ -18,7 +18,8 @@ namespace SpanJson.AspNetCore.Formatter
         {
             if (context.Object != null)
             {
-                return JsonSerializer.NonGeneric.Utf8.SerializeAsync<TResolver>(context.Object, context.HttpContext.Response.Body).AsTask();
+                var valueTask = JsonSerializer.NonGeneric.Utf8.SerializeAsync<TResolver>(context.Object, context.HttpContext.Response.Body);
+                return valueTask.IsCompletedSuccessfully ? Task.CompletedTask : valueTask.AsTask();
             }
 
             return Task.CompletedTask;

--- a/SpanJson.Tests/ReadAllTests.cs
+++ b/SpanJson.Tests/ReadAllTests.cs
@@ -15,9 +15,9 @@ namespace SpanJson.Tests
 
         private static readonly string HelloWorld = "{ \"message\": \"Hello, World!\" }";
 
-        private static readonly string PrettyPrinted1 = "{\r\n  \"First\": 1,\r\n  \"Value\": null,\r\n  \"Child\": null\r\n}";
-        private static readonly string PrettyPrinted2 = "{\r\n\t\"First\"\t:\t1,\r\n\t\"Second\":\true\t,\r\n\t\"Third\":\tnull\t\r\n}";
-        private static readonly string PrettyPrinted3 = "{\r\n  \"First\" : 1 , \r\n  \"Second\" : \tfalse\",\r\n  \"Third\": null \r\n }";
+        private static readonly string PrettyPrinted1 = "{\r\n  \"First\": null,\r\n  \"Second\": null,\r\n  \"Third\": null\r\n}";
+        private static readonly string PrettyPrinted2 = "{\r\n\t\"First\"\t:\t1,\r\n\t\"Second\":\ttrue\t,\r\n\t\"Third\":\tnull\t\r\n}";
+        private static readonly string PrettyPrinted3 = "{\r\n  \"First\" : 1 , \r\n  \"Second\" : \tfalse,\r\n  \"Third\": \"t\" \r\n }";
 
         [Theory]
         [MemberData(nameof(GetUtf8Data))]
@@ -43,6 +43,22 @@ namespace SpanJson.Tests
             }
         }
 
+        [Theory]
+        [MemberData(nameof(GetUtf8DataPretty))]
+        public void ReadAllUtf8PrettyType(byte[] input)
+        {
+            var deserialized = JsonSerializer.Generic.Utf8.Deserialize<PrettyType>(input);
+            Assert.NotNull(deserialized);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetUtf16DataPretty))]
+        public void ReadAllUtf16PrettyType(string input)
+        {
+            var deserialized = JsonSerializer.Generic.Utf16.Deserialize<PrettyType>(input);
+            Assert.NotNull(deserialized);
+        }
+
         public static IEnumerable<object[]> GetUtf16Data()
         {
             yield return new object[] {HeavyNestedJson};
@@ -52,14 +68,34 @@ namespace SpanJson.Tests
             yield return new object[] {PrettyPrinted3};
         }
 
-
         public static IEnumerable<object[]> GetUtf8Data()
         {
-            yield return new object[] {Encoding.UTF8.GetBytes(HeavyNestedJson)};
-            yield return new object[] {Encoding.UTF8.GetBytes(HelloWorld)};
+            yield return new object[] { Encoding.UTF8.GetBytes(HeavyNestedJson) };
+            yield return new object[] { Encoding.UTF8.GetBytes(HelloWorld) };
+            yield return new object[] { Encoding.UTF8.GetBytes(PrettyPrinted1) };
+            yield return new object[] { Encoding.UTF8.GetBytes(PrettyPrinted2) };
+            yield return new object[] { Encoding.UTF8.GetBytes(PrettyPrinted3) };
+        }
+
+        public static IEnumerable<object[]> GetUtf8DataPretty()
+        {
             yield return new object[] {Encoding.UTF8.GetBytes(PrettyPrinted1)};
             yield return new object[] {Encoding.UTF8.GetBytes(PrettyPrinted2)};
             yield return new object[] {Encoding.UTF8.GetBytes(PrettyPrinted3)};
+        }
+
+        public static IEnumerable<object[]> GetUtf16DataPretty()
+        {
+            yield return new object[] { PrettyPrinted1 };
+            yield return new object[] { PrettyPrinted2 };
+            yield return new object[] { PrettyPrinted3 };
+        }
+
+        public class PrettyType
+        {
+            public int? First { get; set; }
+            public bool? Second { get; set; }
+            public string Third { get; set; }
         }
     }
 }

--- a/SpanJson.Tests/Tests.cs
+++ b/SpanJson.Tests/Tests.cs
@@ -187,6 +187,10 @@ namespace SpanJson.Tests
             serialized = JsonSerializer.PrettyPrinter.Print(serialized);
             Assert.Contains("\r\n", serialized);
             Assert.Contains(": ", serialized);
+            serialized = serialized.Replace(": ", " : "); // make sure we have even more whitespaces in
+            serialized = serialized.Replace(",", " ,");
+            serialized = serialized.Replace("]", " ]");
+            serialized = serialized.Replace("[", " [");
             Assert.NotNull(serialized);
             var deserialized = JsonSerializer.NonGeneric.Utf16.Deserialize(serialized, modelType);
             Assert.NotNull(deserialized);
@@ -206,6 +210,11 @@ namespace SpanJson.Tests
             var serializedAsString = Encoding.UTF8.GetString(serialized);
             Assert.Contains("\r\n", serializedAsString);
             Assert.Contains(": ", serializedAsString);
+            serializedAsString = serializedAsString.Replace(": ", " : ");
+            serializedAsString = serializedAsString.Replace(",", " ,");
+            serializedAsString = serializedAsString.Replace("]", " ]");
+            serializedAsString = serializedAsString.Replace("[", " [");
+            serialized = Encoding.UTF8.GetBytes(serializedAsString);
             var deserialized = JsonSerializer.NonGeneric.Utf8.Deserialize(serialized, modelType);
             Assert.NotNull(deserialized);
             Assert.IsType(modelType, deserialized);

--- a/SpanJson/JsonReader.Utf16.cs
+++ b/SpanJson/JsonReader.Utf16.cs
@@ -332,6 +332,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf16();
             var span = ReadUtf16StringSpanInternal(out var escapedCharsSize);
+            SkipWhitespaceUtf16();
             if (_chars[_pos++] != JsonUtf16Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);
@@ -345,6 +346,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf16();
             var span = ReadUtf16StringSpanInternal(out _);
+            SkipWhitespaceUtf16();
             if (_chars[_pos++] != JsonUtf16Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);
@@ -358,6 +360,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf16();
             var span = ReadUtf16StringSpanInternal(out var escapedCharsSize);
+            SkipWhitespaceUtf16();
             if (_chars[_pos++] != JsonUtf16Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);

--- a/SpanJson/JsonReader.Utf8.cs
+++ b/SpanJson/JsonReader.Utf8.cs
@@ -310,6 +310,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf8();
             var span = ReadUtf8StringSpanInternal(out var escapedCharsSize);
+            SkipWhitespaceUtf8();
             if (_bytes[_pos++] != JsonUtf8Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);
@@ -323,6 +324,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf8();
             var span = ReadUtf8StringSpanInternal(out var escapedCharsSize);
+            SkipWhitespaceUtf8();
             if (_bytes[_pos++] != JsonUtf8Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);
@@ -335,6 +337,7 @@ namespace SpanJson
         {
             SkipWhitespaceUtf8();
             var span = ReadUtf8StringSpanInternal(out _);
+            SkipWhitespaceUtf8();
             if (_bytes[_pos++] != JsonUtf8Constant.NameSeparator)
             {
                 ThrowJsonParserException(JsonParserException.ParserError.ExpectedDoubleQuote);


### PR DESCRIPTION
This is a slight (~1%) regression as we forgot to check for whitespaces after the string is done for the matching of property names.
Previously a json with a property with a space between the name and the colon would throw, like {"Key" : "Value"}. This is probably fairly rare, as pretty printing usually writes it {"Key": "Value"} (without the extra space before the colon), but it's valid json and we need to chck for it.