### PR TITLE
upgrade to .net standard 2.1

### DIFF
--- a/SpanJson.Benchmarks/SpanJson.Benchmarks.csproj
+++ b/SpanJson.Benchmarks/SpanJson.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>

--- a/SpanJson.Tests/SpanJson.Tests.csproj
+++ b/SpanJson.Tests/SpanJson.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/SpanJson.WebBenchmark/SpanJson.WebBenchmark.csproj
+++ b/SpanJson.WebBenchmark/SpanJson.WebBenchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AspNetCoreModuleHostingModel>inprocess</AspNetCoreModuleHostingModel>
   </PropertyGroup>
 
@@ -11,8 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.16.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 

--- a/SpanJson.WebBenchmark/Startup.cs
+++ b/SpanJson.WebBenchmark/Startup.cs
@@ -19,13 +19,17 @@ namespace SpanJson.WebBenchmark
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvcCore().AddSerializers().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddMvcCore().AddSerializers().SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(options =>
+            {
+                options.MapDefaultControllerRoute();
+            });
         }
     }
 }

--- a/SpanJson/SpanJson.csproj
+++ b/SpanJson/SpanJson.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>2.0.0</Version>
@@ -24,14 +24,15 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>bin\Debug\netcoreapp2.1\SpanJson.xml</DocumentationFile>
+    <DocumentationFile>bin\Debug\netstandard2.1\SpanJson.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netcoreapp2.1\SpanJson.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard2.1\SpanJson.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.0" />
     <DotNetCliToolReference Include="dotnet-sourcelink" Version="2.8.1" />


### PR DESCRIPTION
For several considerations:
1. .NET Standard project cannot use SpanJson.
2. .NET Standard 2.1 has full Span\<T\> support.
2. Performance was greatly improved in .NET Core 3.0.
3. .NET Core 3.0 will release soon.

Alternatively, you can add reference to System.Buffer and System.Memory with .NET Standard 2.0 instead of .NET Standard 2.1 for wider range of .NET Core versions support.