### PR TITLE
Rewrite unsafe as for arrays

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <Authors>SpanJson Contributors</Authors>
     <Copyright>SpanJson Contributors</Copyright>
     <Company />
-    <Version>3.0.0</Version>	
+    <Version>3.0.1</Version>	
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Tornhoof/SpanJson</PackageProjectUrl>
     <RepositoryUrl>git://github.com/Tornhoof/SpanJson</RepositoryUrl>

--- a/SpanJson/Formatters/Dynamic/SpanJsonDynamic.cs
+++ b/SpanJson/Formatters/Dynamic/SpanJsonDynamic.cs
@@ -29,15 +29,13 @@ namespace SpanJson.Formatters.Dynamic
         {
             if (typeof(TSymbol) == typeof(char))
             {
-                var temp = Symbols;
-                var chars = Unsafe.As<TSymbol[], char[]>(ref temp);
+                var chars = Unsafe.As<char[]>(Symbols);
                 return new string(chars);
             }
 
             if (typeof(TSymbol) == typeof(byte))
             {
-                var temp = Symbols;
-                var bytes = Unsafe.As<TSymbol[], byte[]>(ref temp);
+                var bytes = Unsafe.As<byte[]>(Symbols);
                 return Encoding.UTF8.GetString(bytes);
             }
 

--- a/SpanJson/Formatters/Dynamic/SpanJsonDynamicString.cs
+++ b/SpanJson/Formatters/Dynamic/SpanJsonDynamicString.cs
@@ -92,15 +92,13 @@ namespace SpanJson.Formatters.Dynamic
         {
             if (typeof(TSymbol) == typeof(char))
             {
-                var temp = Symbols;
-                var chars = Unsafe.As<TSymbol[], char[]>(ref temp);
+                var chars = Unsafe.As<char[]>(Symbols);
                 return new string(chars, 1, chars.Length - 2);
             }
 
             if (typeof(TSymbol) == typeof(byte))
             {
-                var temp = Symbols;
-                var bytes = Unsafe.As<TSymbol[], byte[]>(ref temp);
+                var bytes = Unsafe.As<byte[]>(Symbols);
                 return Encoding.UTF8.GetString(bytes, 1, bytes.Length - 2);
             }
 

--- a/SpanJson/JsonSerializer.Generics.cs
+++ b/SpanJson/JsonSerializer.Generics.cs
@@ -58,8 +58,7 @@ namespace SpanJson
                     {
                         Formatter.Serialize(ref jsonWriter, input);
                         _lastSerializationSizeEstimate = jsonWriter.Data.Length;
-                        var temp = jsonWriter.Data;
-                        var data = Unsafe.As<TSymbol[], char[]>(ref temp);
+                        var data = Unsafe.As<char[]>(jsonWriter.Data);
                         return new ArraySegment<char>(data, 0, jsonWriter.Position);
                     }
                     catch
@@ -93,8 +92,7 @@ namespace SpanJson
                     {
                         Formatter.Serialize(ref jsonWriter, input);
                         _lastSerializationSizeEstimate = jsonWriter.Data.Length;
-                        var temp = jsonWriter.Data;
-                        var data = Unsafe.As<TSymbol[], byte[]>(ref temp);
+                        var data = Unsafe.As<byte[]>(jsonWriter.Data);
                         return new ArraySegment<byte>(data, 0, jsonWriter.Position);
                     }
                     catch
@@ -112,8 +110,7 @@ namespace SpanJson
                     {
                         Formatter.Serialize(ref jsonWriter, input);
                         _lastSerializationSizeEstimate = jsonWriter.Data.Length;
-                        var temp = jsonWriter.Data;
-                        var data = Unsafe.As<TSymbol[], char[]>(ref temp);
+                        var data = Unsafe.As<char[]>(jsonWriter.Data);
                         var result = writer.WriteAsync(data, 0, jsonWriter.Position);
                         if (result.IsCompletedSuccessfully)
                         {
@@ -135,8 +132,7 @@ namespace SpanJson
                     {
                         Formatter.Serialize(ref jsonWriter, input);
                         _lastSerializationSizeEstimate = jsonWriter.Data.Length;
-                        var temp = jsonWriter.Data;
-                        var data = Unsafe.As<TSymbol[], byte[]>(ref temp);
+                        var data = Unsafe.As<byte[]>(jsonWriter.Data);
                         var result = stream.WriteAsync(data, 0, jsonWriter.Position, cancellationToken);
                         if (result.IsCompletedSuccessfully)
                         {


### PR DESCRIPTION
Fix #139 by using different Unsafe.As method.