### PR TITLE
Remove escaped solidus from writer

### DIFF
--- a/SpanJson/JsonWriter.Utf16.cs
+++ b/SpanJson/JsonWriter.Utf16.cs
@@ -309,7 +309,7 @@ namespace SpanJson
             }
 
             WriteUtf16DoubleQuote();
-            if (value < 0x20 || value == JsonUtf16Constant.DoubleQuote || value == JsonUtf16Constant.Solidus || value == JsonUtf16Constant.ReverseSolidus)
+            if (value < 0x20 || value == JsonUtf16Constant.DoubleQuote || value == JsonUtf16Constant.ReverseSolidus)
             {
                 WriteEscapedUtf16CharInternal(value);
             }
@@ -405,7 +405,7 @@ namespace SpanJson
             for (var i = 0; i < value.Length; i++)
             {
                 ref readonly var c = ref value[i];
-                if (c < 0x20 || c == JsonUtf16Constant.DoubleQuote || c == JsonUtf16Constant.Solidus || c == JsonUtf16Constant.ReverseSolidus)
+                if (c < 0x20 || c == JsonUtf16Constant.DoubleQuote || c == JsonUtf16Constant.ReverseSolidus)
                 {
                     WriteEscapedUtf16CharInternal(c);
                     var remaining = 5 + value.Length - i; // make sure that all characters and an extra 5 for a full escape still fit

--- a/SpanJson/JsonWriter.Utf8.cs
+++ b/SpanJson/JsonWriter.Utf8.cs
@@ -272,7 +272,7 @@ namespace SpanJson
             while (index < value.Length)
             {
                 ref readonly var c = ref value[index];
-                if (c < 0x20 || c == JsonUtf8Constant.DoubleQuote || c == JsonUtf8Constant.Solidus || c == JsonUtf8Constant.ReverseSolidus)
+                if (c < 0x20 || c == JsonUtf8Constant.DoubleQuote || c == JsonUtf8Constant.ReverseSolidus)
                 {
                     // changed extraBytes to 0 and post grow the buffer, if required, by atleast 7, the previous code failed in some rare combinations of content and buffer size
                     // instead of checking the buffer size here to get atleast the 7 extra bytes in, we do it after writing the initial buffer (which works due to Grow above)
@@ -437,7 +437,7 @@ namespace SpanJson
         private void WriteUtf8CharInternal(char value)
         {
             ref var pos = ref _pos;
-            if (value < 0x20 || value == JsonUtf8Constant.DoubleQuote || value == JsonUtf8Constant.Solidus || value == JsonUtf8Constant.ReverseSolidus)
+            if (value < 0x20 || value == JsonUtf8Constant.DoubleQuote || value == JsonUtf8Constant.ReverseSolidus)
             {
                 WriteEscapedUtf8CharInternal(value);
             }


### PR DESCRIPTION
Though a forward slash may be escaped it is not required and can break some use cases. I was trying out this library for Json logging and having solidus escaped breaks literal comparisons with many text tools.

For example, when using `grep` to search a log file named logfile for the url 'https://github.com' one would have to write the following command:
`grep "https:\\\\/\\\\/github.com" logfile` instead of the expected `grep "https://github.com" logfile`

The 4 backslashes in the example is because one has to escape the characters from the shell as well, while in other circumstances one should supply only 2, which only serves to complicate matters.