### PR TITLE
Allow serialization of classes without default constructors or [JsonConstructor]

### DIFF
--- a/SpanJson.Tests/ConstructorAttributeTests.cs
+++ b/SpanJson.Tests/ConstructorAttributeTests.cs
@@ -407,22 +407,30 @@ namespace SpanJson.Tests
 
             }
 
-            protected override void TryGetAnnotatedAttributeConstructor(Type type, out ConstructorInfo constructor, out JsonConstructorAttribute attribute)
+            protected override void GetConstructorInfo(Type type, out ConstructorInfo constructor, out JsonConstructorAttribute attribute, out bool hasDefaultConstructor)
             {
-                constructor = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                    .FirstOrDefault(a => a.GetCustomAttribute<JsonConstructorAttribute>() != null);
-                if (constructor != null)
+                constructor = null;
+                attribute = null;
+                hasDefaultConstructor = type.IsValueType;
+
+                var ctors = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                int bestConstructorParamCount = 0;
+                foreach (var ctor in ctors)
                 {
-                    attribute = constructor.GetCustomAttribute<JsonConstructorAttribute>();
-                    return;
+                    var currentAttribute = ctor.GetCustomAttribute<JsonConstructorAttribute>();
+                    var currentParamCount = ctor.GetParameters().Length;
+                    if (currentParamCount == 0) hasDefaultConstructor = true;
+                    if ((attribute is null || currentAttribute is not null) && currentParamCount > bestConstructorParamCount)
+                    {
+                        constructor = ctor;
+                        attribute = currentAttribute;
+                        bestConstructorParamCount = currentParamCount;
+                    }
                 }
 
-                if (TryGetBaseClassJsonConstructorAttribute(type, out attribute))
+                if (attribute is not null) return;
+                if (TryGetBaseClassJsonConstructorAttribute(type, out attribute) || type.GetMethod("<Clone>$") != null)
                 {
-                    // We basically take the one with the most parameters, this needs to match the dictionary // TODO find better method
-                    constructor = type.GetConstructors(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                        .OrderByDescending(a => a.GetParameters().Length)
-                        .FirstOrDefault();
                     return;
                 }
 

--- a/SpanJson.Tests/DateTests.cs
+++ b/SpanJson.Tests/DateTests.cs
@@ -275,7 +275,7 @@ namespace SpanJson.Tests
             value = value.AddTicks(-(value.Ticks % TimeSpan.TicksPerSecond));
             var offset = TimeZoneInfo.Local.GetUtcOffset(value);
             var output = value.ToString("yyyy-MM-ddTHH:mm:ss");
-            var sign = offset.Hours < 0 ? '-' : '+';
+            var sign = offset.Hours < 0 ? "" : "+";
             output = output + sign + $"{offset.Hours:D2}:{offset.Minutes:D2}";
             Span<char> charSpan = stackalloc char[35];
             Assert.True(DateTimeFormatter.TryFormat(value, charSpan, out var symbolsWritten));

--- a/SpanJson.Tests/OptionalDeserializer.cs
+++ b/SpanJson.Tests/OptionalDeserializer.cs
@@ -1,0 +1,80 @@
+using System;
+using Xunit;
+
+namespace SpanJson.Tests
+{
+    public class NestedClass
+    {
+        public int InnerValue { get; set; }
+    }
+
+    public class NoDefaultConstructorClass
+    {
+        public NoDefaultConstructorClass(int value, int renamedValue, NestedClass nested)
+        {
+            Value = value;
+            OtherNamedValue = renamedValue;
+            Nested = nested;
+        }
+
+        public int Value { get; set; }
+        public int OtherNamedValue { get; set; }
+        public NestedClass Nested { get; set; }
+    }
+
+    public struct NoDefaultConstructorStruct
+    {
+        public NoDefaultConstructorStruct(int value, int renamedValue, NestedClass nested)
+        {
+            Value = value;
+            OtherNamedValue = renamedValue;
+            Nested = nested;
+        }
+
+        public int Value { get; set; }
+        public int OtherNamedValue { get; set; }
+        public NestedClass Nested { get; set; }
+    }
+
+
+    public class OptionalDeserializer
+    {
+        private const string SourceJson = "{\"Value\":42,\"RenamedValue\":1337,\"Nested\":{\"InnerValue\":9001}}";
+        private const string ConstructedAsJson = "{\"Value\":42,\"OtherNamedValue\":1337,\"Nested\":{\"InnerValue\":9001}}";
+
+        [Fact]
+        public void ShouldBeAbleToSerializeClassWithNoDefaultConstructor() {
+            var nested = new NestedClass { InnerValue = 9001 };
+            var instance = new NoDefaultConstructorClass(42, 1337, nested);
+            var actual = JsonSerializer.Generic.Utf16.Serialize(instance);
+            var expected = ConstructedAsJson;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ShouldNotBeAbleToDeserializeClassWithNoDefaultConstructor() {
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Generic.Utf16.Deserialize<NoDefaultConstructorClass>(SourceJson));
+        }
+
+        // Unlike classes, structs always have a "default constructor", even if you provide your own constructor.
+        [Fact]
+        public void ShouldBeAbleToSerializeStructWithNoDefaultConstructor()
+        {
+            var nested = new NestedClass { InnerValue = 9001 };
+            var instance = new NoDefaultConstructorStruct(42, 1337, nested);
+            var actual = JsonSerializer.Generic.Utf16.Serialize(instance);
+            var expected = ConstructedAsJson;
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ShouldBeAbleToDeserializeStructWithNoDefaultConstructor()
+        {
+            var instance = JsonSerializer.Generic.Utf16.Deserialize<NoDefaultConstructorStruct>(SourceJson);
+            Assert.Equal(42, instance.Value);
+            // Prove that the parameter-having constructor was not called.
+            Assert.Equal(0, instance.OtherNamedValue);
+            Assert.Equal(9001, instance.Nested.InnerValue);
+        }
+    }
+}

--- a/SpanJson/Formatters/ComplexFormatter.cs
+++ b/SpanJson/Formatters/ComplexFormatter.cs
@@ -345,7 +345,7 @@ namespace SpanJson.Formatters
                 static string ToPascalCase(string name) => char.ToUpperInvariant(name[0]) + name.Substring(1);
                 static string ToCamelCase(string name) => char.ToLowerInvariant(name[0]) + name.Substring(1);
             }
-            else
+            else if (objectDescription.HasDefaultConstructor)
             {
                 // The normal assign to member type
                 matchExpressionFunctor = memberInfo =>
@@ -358,6 +358,14 @@ namespace SpanJson.Formatters
                             FindPublicInstanceMethod(formatterType, "Deserialize", readerParameter.Type.MakeByRefType()),
                             readerParameter));
                 };
+            }
+            else
+            {
+                return Expression
+                    .Lambda<DeserializeDelegate<T, TSymbol>>(Expression.Block(
+                            Expression.Throw(Expression.Constant(new InvalidOperationException($"{typeof(T).Name} does not have a default constructor."))),
+                            Expression.Default(typeof(T))),
+                        readerParameter).Compile();
             }
 
             var nameSpan = Expression.Variable(typeof(ReadOnlySpan<TSymbol>), "nameSpan");

--- a/SpanJson/Resolvers/JsonObjectDescription.cs
+++ b/SpanJson/Resolvers/JsonObjectDescription.cs
@@ -7,12 +7,13 @@ namespace SpanJson.Resolvers
 {
     public class JsonObjectDescription : IReadOnlyList<JsonMemberInfo>
     {
-        public JsonObjectDescription(ConstructorInfo constructor, JsonConstructorAttribute attribute, JsonMemberInfo[] members, JsonExtensionMemberInfo extensionMemberInfo)
+        public JsonObjectDescription(ConstructorInfo constructor, JsonConstructorAttribute attribute, bool hasDefaultConstructor, JsonMemberInfo[] members, JsonExtensionMemberInfo extensionMemberInfo)
         {
             Members = members;
             ExtensionMemberInfo = extensionMemberInfo;
             Constructor = constructor;
             Attribute = attribute;
+            HasDefaultConstructor = hasDefaultConstructor;
             if (Constructor != null)
             {
                 ConstructorMapping = BuildMapping();
@@ -47,6 +48,7 @@ namespace SpanJson.Resolvers
 
         public ConstructorInfo Constructor { get; }
         public JsonConstructorAttribute Attribute { get; }
+        public bool HasDefaultConstructor { get; }
         public JsonMemberInfo[] Members { get; }
         public JsonExtensionMemberInfo ExtensionMemberInfo { get; }
         public IReadOnlyDictionary<string, (Type Type, int Index)> ConstructorMapping { get; }


### PR DESCRIPTION
As noted in #129, both the serializer and deserializer are constructed at the same time. Due to the metadata not being available, `BuildDeserializeDelegate` incorrectly assumes it can default-construct a `class`. This pull request adds in the correct metadata so it can determine that would fail. Instead, it does the same as above (in `BuildDeserializeDelegate`) where it throws due to the `class` having `abstract` members. That is, it throws when you attempt to actually deserialize.

This pull request also fixes an unrelated test that was failing for me -- thankfully, the test code was wrong, not the implementation.